### PR TITLE
POC: Event backbone (AWS & GCP) — plans, schemas, metrics

### DIFF
--- a/poc/event-backbone/README.md
+++ b/poc/event-backbone/README.md
@@ -1,0 +1,37 @@
+# Event Backbone PoC — AWS vs GCP
+
+目的: 低コスト・低運用のイベント基盤（AWS vs GCP）を同一シナリオで比較検証し、MVPの主クラウドを決定する。
+
+対象シナリオ（共通）
+- `pm.timesheet.approved` → `fi.invoice.generated`
+- 集約ID: `timesheetId`（ordering key / message group id）
+- 冪等性: Idempotency-Key + 重複検知テーブル
+
+評価観点（重み例）
+- コスト（30%）: 月額/1万・10万イベント時の概算
+- 運用（25%）: 監視/アラート、DLQ/リドライブ、IaCの容易さ
+- 性能（20%）: E2E p95、スループット安定性、スパイク耐性
+- 信頼性（15%）: 再処理、順序保証（集約ID単位）、耐障害性
+- 開発体験（10%）: SDK/ローカルテスト、デバッグ容易性
+
+測定項目
+- レイテンシ: Pub→Consume→DB/Stub完了までのE2E（p50/p95）
+- 失敗処理: DLQ移送率、リトライ成功率
+- 重複抑止: 冪等処理の成功率
+- コスト: サービス別（イベント・リクエスト・GB秒・ストレージ）
+
+計測方法
+- 送信ツール: バッチ送信（100/1,000/10,000 events）
+- サンプリング: 各負荷で3回、平均/分位を採取
+- 可観測性: 各クラウド標準モニタリング + ログ（trace id付）
+
+成果物
+- 比較レポート（metrics.mdのテンプレに記入）
+- 決定チケット（Issues #9）への結論/根拠の記載
+
+関連
+- AWS案: aws.md
+- GCP案: gcp.md
+- 共通スキーマ: schema/timesheet_approved.json, schema/invoice_generated.json
+- メトリクステンプレ: metrics.md
+

--- a/poc/event-backbone/aws.md
+++ b/poc/event-backbone/aws.md
@@ -1,0 +1,33 @@
+# AWS PoC: EventBridge + SQS (FIFO) + Lambda
+
+アーキテクチャ
+- EventBridge: `pm.timesheet.approved` 受信 → ルールで SQS FIFO に転送
+- SQS FIFO: `MessageGroupId=timesheetId` で順序確保、DLQ設定
+- Lambda: コンシューマ（冪等処理: Idempotency-Key + 重複検知テーブル）
+- 監査/保管: EventBridge Archive/Replay + S3 (WORM)
+- 監視: CloudWatch Alarms（キュー深さ、失敗率、DLQ増加）
+
+実施手順（概要）
+1) Event命名/スキーマ確定（schema/*.json）
+2) EventBridge バス/ルール作成（フィルタ: `detail-type`, `source`, `detail.action` 等）
+3) SQS FIFO 作成（Content-based dedup off, DLQ 紐付け）
+4) Lambda 作成（Node.js/TypeScript）
+   - 入力: SQSイベント
+   - 処理: 冪等チェック→Invoiceドラフト作成（モック）→結果ログ
+5) Archive/Replay 有効化、S3 への定期エクスポート（7年）
+6) CloudWatch ダッシュボード/アラーム作成
+
+測定
+- E2Eレイテンシ: 送信時刻→Lambda完了時刻
+- スループット: バッチ送信（100/1,000/10,000 events）
+- 失敗シナリオ: わざと失敗→DLQ→リドライブ
+- 冪等確認: 同一Idempotency-Key再送
+
+概算コスト（目安）
+- EventBridge（イベント課金）、SQS（リクエスト課金）、Lambda（GB秒/リクエスト）
+- MVP規模（数万イベント/月）: 数千円〜1万円台
+
+注意
+- 大きなペイロードはS3格納、イベントは参照URL
+- VPCエンドポイントでNATコスト節約
+

--- a/poc/event-backbone/gcp.md
+++ b/poc/event-backbone/gcp.md
@@ -1,0 +1,32 @@
+# GCP PoC: Pub/Sub + Cloud Run (+ Eventarc)
+
+アーキテクチャ
+- Pub/Sub: `pm.timesheet.approved` をトピック配信（ordering key=timesheetId）
+- サブスクリプション: DLT設定、ack期限/再試行ポリシー
+- Cloud Run: Push 受信コンシューマ（冪等処理: Idempotency-Key + 重複検知テーブル）
+- 監査/保管: BigQuery/GCS シンク（7年はGCSで保管）
+- 監視: Cloud Monitoring（サブスクリプションlag、error率）、Error Reporting
+
+実施手順（概要）
+1) Event命名/スキーマ確定（schema/*.json）
+2) Pub/Sub トピック/サブスクリプション作成（ordering/dlt/再試行）
+3) Cloud Run サービス作成（Node.js/TypeScript）
+   - 入力: Pub/Sub push
+   - 処理: 冪等チェック→Invoiceドラフト作成（モック）→結果ログ
+4) BigQuery/GCS シンク設定（長期保管）
+5) Monitoring/アラート設定
+
+測定
+- E2Eレイテンシ: 送信時刻→Cloud Run 完了時刻
+- スループット: バッチ送信（100/1,000/10,000 events）
+- 失敗シナリオ: わざと失敗→DLT→リドライブ
+- 冪等確認: 同一Idempotency-Key再送
+
+概算コスト（目安）
+- Pub/Sub（メッセージ課金）、Cloud Run（リク/CPU・メモリ秒）、BigQuery/GCS（保存/取り込み）
+- MVP規模（数万イベント/月）: 数千円〜1万円台
+
+注意
+- 大きなペイロードはGCS格納、イベントは参照URL
+- Serverless VPC Access や VPC-SC で境界強化（必要時）
+

--- a/poc/event-backbone/metrics.md
+++ b/poc/event-backbone/metrics.md
@@ -1,0 +1,29 @@
+# PoC Metrics Template
+
+## Workload
+- Batches: 100 / 1,000 / 10,000 events
+- Payload size (bytes): avg / p95 / max
+
+## AWS Results
+- E2E latency (ms): p50 / p95 / p99 (per batch size)
+- Throughput (events/s): sustained / peak
+- Failures: % to DLQ / recovery time
+- Idempotency: duplicate sends blocked (%)
+- Cost (estimated/month): EventBridge / SQS / Lambda / S3
+
+## GCP Results
+- E2E latency (ms): p50 / p95 / p99 (per batch size)
+- Throughput (events/s): sustained / peak
+- Failures: % to DLT / recovery time
+- Idempotency: duplicate sends blocked (%)
+- Cost (estimated/month): Pub/Sub / Cloud Run / BigQuery / GCS
+
+## Observations
+- Operational notes (alerts, dashboards)
+- DX (local testing, logs, traces)
+- Risks & mitigations
+
+## Decision Summary
+- Winner: AWS | GCP
+- Rationale: cost / ops / performance / reliability / DX
+

--- a/poc/event-backbone/schema/invoice_generated.json
+++ b/poc/event-backbone/schema/invoice_generated.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://itdo-erp3/poc/schema/invoice_generated.json",
+  "title": "fi.invoice.generated",
+  "type": "object",
+  "properties": {
+    "eventId": { "type": "string", "format": "uuid" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "tenantId": { "type": "string" },
+    "invoiceId": { "type": "string" },
+    "timesheetId": { "type": "string" },
+    "projectId": { "type": "string" },
+    "customerId": { "type": "string" },
+    "amount": { "type": "number", "minimum": 0 },
+    "currency": { "type": "string", "minLength": 3, "maxLength": 3 },
+    "idempotencyKey": { "type": "string" }
+  },
+  "required": ["eventId", "occurredAt", "invoiceId", "timesheetId", "projectId", "customerId", "amount", "currency"],
+  "additionalProperties": false
+}
+

--- a/poc/event-backbone/schema/timesheet_approved.json
+++ b/poc/event-backbone/schema/timesheet_approved.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://itdo-erp3/poc/schema/timesheet_approved.json",
+  "title": "pm.timesheet.approved",
+  "type": "object",
+  "properties": {
+    "eventId": { "type": "string", "format": "uuid" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "tenantId": { "type": "string" },
+    "timesheetId": { "type": "string" },
+    "employeeId": { "type": "string" },
+    "projectId": { "type": "string" },
+    "approvedBy": { "type": "string" },
+    "hours": { "type": "number", "minimum": 0 },
+    "rateType": { "type": "string", "enum": ["standard", "overtime", "holiday", "night"] },
+    "idempotencyKey": { "type": "string" }
+  },
+  "required": ["eventId", "occurredAt", "timesheetId", "employeeId", "projectId", "approvedBy", "hours", "rateType"],
+  "additionalProperties": false
+}
+


### PR DESCRIPTION
Add PoC docs to compare AWS vs GCP event backbones using the same scenario (timesheet approved → invoice generated):

- poc/event-backbone/README.md: goals, evaluation criteria, measurement plan
- poc/event-backbone/aws.md: EventBridge + SQS FIFO + Lambda steps
- poc/event-backbone/gcp.md: Pub/Sub + Cloud Run (+ Eventarc) steps
- poc/event-backbone/schema/*.json: shared JSON Schemas
- poc/event-backbone/metrics.md: results template

Will use Issues #10 (AWS PoC) and #11 (GCP PoC) to track execution and capture results.
