### PR TITLE
POC: Prefill metrics with AWS/GCP result sections (TBD placeholders)

### DIFF
--- a/poc/event-backbone/metrics.md
+++ b/poc/event-backbone/metrics.md
@@ -3,27 +3,59 @@
 ## Workload
 - Batches: 100 / 1,000 / 10,000 events
 - Payload size (bytes): avg / p95 / max
+- Runs: 3 per batch size (average the results)
 
 ## AWS Results
-- E2E latency (ms): p50 / p95 / p99 (per batch size)
-- Throughput (events/s): sustained / peak
-- Failures: % to DLQ / recovery time
-- Idempotency: duplicate sends blocked (%)
-- Cost (estimated/month): EventBridge / SQS / Lambda / S3
+
+### 100 events
+- E2E latency (ms): p50=TBD / p95=TBD / p99=TBD
+- Throughput (events/s): sustained=TBD / peak=TBD
+- Failures: to DLQ=TBD% / recovery time=TBDs
+- Idempotency: duplicates blocked=TBD%
+- Cost est. (month): EventBridge=TBD / SQS=TBD / Lambda=TBD / S3=TBD
+
+### 1,000 events
+- E2E latency (ms): p50=TBD / p95=TBD / p99=TBD
+- Throughput (events/s): sustained=TBD / peak=TBD
+- Failures: to DLQ=TBD% / recovery time=TBDs
+- Idempotency: duplicates blocked=TBD%
+- Cost est. (month): EventBridge=TBD / SQS=TBD / Lambda=TBD / S3=TBD
+
+### 10,000 events
+- E2E latency (ms): p50=TBD / p95=TBD / p99=TBD
+- Throughput (events/s): sustained=TBD / peak=TBD
+- Failures: to DLQ=TBD% / recovery time=TBDs
+- Idempotency: duplicates blocked=TBD%
+- Cost est. (month): EventBridge=TBD / SQS=TBD / Lambda=TBD / S3=TBD
 
 ## GCP Results
-- E2E latency (ms): p50 / p95 / p99 (per batch size)
-- Throughput (events/s): sustained / peak
-- Failures: % to DLT / recovery time
-- Idempotency: duplicate sends blocked (%)
-- Cost (estimated/month): Pub/Sub / Cloud Run / BigQuery / GCS
+
+### 100 events
+- E2E latency (ms): p50=TBD / p95=TBD / p99=TBD
+- Throughput (events/s): sustained=TBD / peak=TBD
+- Failures: to DLT=TBD% / recovery time=TBDs
+- Idempotency: duplicates blocked=TBD%
+- Cost est. (month): Pub/Sub=TBD / Cloud Run=TBD / BigQuery=TBD / GCS=TBD
+
+### 1,000 events
+- E2E latency (ms): p50=TBD / p95=TBD / p99=TBD
+- Throughput (events/s): sustained=TBD / peak=TBD
+- Failures: to DLT=TBD% / recovery time=TBDs
+- Idempotency: duplicates blocked=TBD%
+- Cost est. (month): Pub/Sub=TBD / Cloud Run=TBD / BigQuery=TBD / GCS=TBD
+
+### 10,000 events
+- E2E latency (ms): p50=TBD / p95=TBD / p99=TBD
+- Throughput (events/s): sustained=TBD / peak=TBD
+- Failures: to DLT=TBD% / recovery time=TBDs
+- Idempotency: duplicates blocked=TBD%
+- Cost est. (month): Pub/Sub=TBD / Cloud Run=TBD / BigQuery=TBD / GCS=TBD
 
 ## Observations
-- Operational notes (alerts, dashboards)
-- DX (local testing, logs, traces)
-- Risks & mitigations
+- Operational notes (alerts, dashboards): TBD
+- DX (local testing, logs, traces): TBD
+- Risks & mitigations: TBD
 
 ## Decision Summary
-- Winner: AWS | GCP
-- Rationale: cost / ops / performance / reliability / DX
-
+- Winner: AWS | GCP (TBD)
+- Rationale: cost / ops / performance / reliability / DX (TBD)


### PR DESCRIPTION
Add structured sections in poc/event-backbone/metrics.md for 100/1,000/10,000 events across AWS and GCP, with TBD placeholders to be filled during PoC runs (#10, #11).