### PR TITLE
Local PoC: Dockerized RabbitMQ+Redis producer/consumer (ordering, idempotency, DLQ)

### DIFF
--- a/poc/event-backbone/local/README.md
+++ b/poc/event-backbone/local/README.md
@@ -1,0 +1,44 @@
+# Local PoC (Docker): RabbitMQ + Redis + Node services
+
+目的: クラウド不要で、timesheet approved → invoice generated のE2Eをローカルコンテナで再現し、順序/冪等/失敗復旧を検証する。
+
+構成
+- RabbitMQ (direct exchange `events`, shardキュー `shard.0..N-1`, DLQあり)
+- Redis (Idempotency-Key で重複抑止)
+- Producer (timesheet_approved を発行、timesheetIdでシャーディング)
+- Consumer (各shardを単一コンシューマで処理→invoice_generatedをログ出力)
+
+前提
+- Docker / Docker Compose が利用可能
+
+起動
+```
+cd poc/event-backbone/local
+docker compose up --build
+```
+
+設定（環境変数）
+- NUM_SHARDS: シャード数（デフォルト4）
+- PRODUCER_BATCH: 送信イベント数（デフォルト100）
+- PRODUCER_RPS: 送信レート（events/s, デフォルト50）
+- FAIL_RATE: 失敗率（0.0-1.0, デフォルト0.0）→DLQ動作の検証に使用
+
+テスト
+- Producerログ: 送信件数とシャード割り当て
+- Consumerログ: invoice生成（冪等時はskip表示）
+- RabbitMQ管理画面: http://localhost:15672 （user: guest / pass: guest）
+- Redis: idempotencyキーを格納（`idemp:{key}`）
+
+想定確認
+- 再送（同一Idempotency-Key）→重複抑止（skip）
+- 同一timesheetId→同一shard→コンシューマ単一で順序維持
+- FAIL_RATE>0 でDLQへ退避→手動でリドライブ（管理画面 or rabbitmqadmin）
+
+終了
+```
+docker compose down -v
+```
+
+メモ
+- 大きなペイロードはS3互換（MinIO）での格納も可能。必要ならcomposeにMinIOサービスを追加して参照URL方式に拡張可能です。
+

--- a/poc/event-backbone/local/consumer/Dockerfile
+++ b/poc/event-backbone/local/consumer/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY index.js package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/consumer/package.json
+++ b/poc/event-backbone/local/consumer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "local-consumer",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "amqplib": "^0.10.3",
+    "ioredis": "^5.4.1"
+  }
+}
+

--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.9'
+services:
+  rabbitmq:
+    image: rabbitmq:3.12-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  producer:
+    build: ./producer
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - PRODUCER_BATCH=${PRODUCER_BATCH:-100}
+      - PRODUCER_RPS=${PRODUCER_RPS:-50}
+    depends_on:
+      - rabbitmq
+
+  consumer:
+    build: ./consumer
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - REDIS_URL=redis://redis:6379
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - FAIL_RATE=${FAIL_RATE:-0.0}
+    depends_on:
+      - rabbitmq
+      - redis
+

--- a/poc/event-backbone/local/producer/Dockerfile
+++ b/poc/event-backbone/local/producer/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY index.js package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/producer/index.js
+++ b/poc/event-backbone/local/producer/index.js
@@ -1,0 +1,75 @@
+import amqp from 'amqplib';
+import { nanoid } from 'nanoid';
+
+const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@localhost:5672';
+const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
+const BATCH = parseInt(process.env.PRODUCER_BATCH || '100', 10);
+const RPS = parseInt(process.env.PRODUCER_RPS || '50', 10);
+
+function shardFor(key) {
+  let h = 0;
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+  return h % NUM_SHARDS;
+}
+
+async function main() {
+  const conn = await amqp.connect(AMQP_URL);
+  const ch = await conn.createChannel();
+  const ex = 'events';
+  await ch.assertExchange(ex, 'direct', { durable: true });
+
+  // declare shard queues and bindings (idempotent)
+  for (let i = 0; i < NUM_SHARDS; i++) {
+    const q = `shard.${i}`;
+    await ch.assertQueue(q, {
+      durable: true,
+      deadLetterExchange: 'dlx',
+      deadLetterRoutingKey: q + '.dead'
+    });
+    await ch.bindQueue(q, ex, `shard.${i}`);
+    await ch.assertExchange('dlx', 'direct', { durable: true });
+    await ch.assertQueue(q + '.dead', { durable: true });
+    await ch.bindQueue(q + '.dead', 'dlx', q + '.dead');
+  }
+
+  let sent = 0;
+  const interval = 1000 / Math.max(1, RPS);
+
+  const timer = setInterval(() => {
+    if (sent >= BATCH) {
+      clearInterval(timer);
+      setTimeout(() => { conn.close().catch(()=>{}); }, 500);
+      return;
+    }
+    // simulate some timesheetIds (repeat to test ordering)
+    const timesheetId = 'TS-' + ((sent % Math.min(10, BATCH)) + 1).toString().padStart(3, '0');
+    const eventId = nanoid();
+    const idempotencyKey = nanoid();
+    const payload = {
+      eventId,
+      occurredAt: new Date().toISOString(),
+      tenantId: 'demo',
+      timesheetId,
+      employeeId: 'E-001',
+      projectId: 'P-001',
+      approvedBy: 'M-001',
+      hours: 8,
+      rateType: 'standard',
+      idempotencyKey
+    };
+    const shard = shardFor(timesheetId);
+    const ok = ch.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(payload)), {
+      contentType: 'application/json',
+      messageId: eventId,
+      headers: { idempotencyKey, timesheetId }
+    });
+    if (ok) sent++;
+    if (sent % 10 === 0) console.log(`[producer] sent ${sent}/${BATCH}`);
+  }, interval);
+}
+
+main().catch((e) => {
+  console.error('[producer] error', e);
+  process.exit(1);
+});
+

--- a/poc/event-backbone/local/producer/package.json
+++ b/poc/event-backbone/local/producer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "local-producer",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "amqplib": "^0.10.3",
+    "nanoid": "^5.0.7"
+  }
+}
+


### PR DESCRIPTION
Add a cloud-free PoC that emulates the event backbone locally with RabbitMQ (sharded queues) and Redis (idempotency). Includes docker-compose, producer/consumer services, DLQ, and README. Useful for offline testing alongside AWS/GCP PoCs (#10, #11).