### PR TITLE
Local PoC: MinIO support + E2E latency logging

### DIFF
--- a/poc/event-backbone/local/consumer/index.js
+++ b/poc/event-backbone/local/consumer/index.js
@@ -27,7 +27,12 @@ async function processMessage(redis, msg) {
 
   // simulate invoice generation
   const invoiceId = `INV-${content.timesheetId}-${Date.now()}`;
-  console.log(`[consumer] invoice generated: ${invoiceId} for ${content.timesheetId}`);
+  const now = Date.now();
+  let latencyMs = null;
+  try { latencyMs = now - new Date(content.occurredAt).getTime(); } catch (_) {}
+  const latencyInfo = latencyMs != null ? ` latency=${latencyMs}ms` : '';
+  const attach = content.attachmentUrl ? ` attachmentUrl=${content.attachmentUrl}` : '';
+  console.log(`[consumer] invoice generated: ${invoiceId} for ${content.timesheetId}${latencyInfo}${attach}`);
   return { status: 'ok', invoiceId };
 }
 
@@ -76,4 +81,3 @@ main().catch((e) => {
   console.error('[consumer] error', e);
   process.exit(1);
 });
-

--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -14,6 +14,16 @@ services:
     ports:
       - "6379:6379"
 
+  minio:
+    image: minio/minio:RELEASE.2024-08-17T01-24-54Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
   producer:
     build: ./producer
     environment:
@@ -21,8 +31,16 @@ services:
       - NUM_SHARDS=${NUM_SHARDS:-4}
       - PRODUCER_BATCH=${PRODUCER_BATCH:-100}
       - PRODUCER_RPS=${PRODUCER_RPS:-50}
+      - USE_MINIO=${USE_MINIO:-false}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio}
+      - MINIO_PORT=${MINIO_PORT:-9000}
+      - MINIO_USE_SSL=${MINIO_USE_SSL:-false}
+      - MINIO_ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}
+      - MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD:-minioadmin}
+      - MINIO_BUCKET=${MINIO_BUCKET:-events}
     depends_on:
       - rabbitmq
+      - minio
 
   consumer:
     build: ./consumer
@@ -34,4 +52,3 @@ services:
     depends_on:
       - rabbitmq
       - redis
-

--- a/poc/event-backbone/local/producer/index.js
+++ b/poc/event-backbone/local/producer/index.js
@@ -1,10 +1,28 @@
 import amqp from 'amqplib';
 import { nanoid } from 'nanoid';
+import Minio from 'minio';
 
 const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@localhost:5672';
 const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
 const BATCH = parseInt(process.env.PRODUCER_BATCH || '100', 10);
 const RPS = parseInt(process.env.PRODUCER_RPS || '50', 10);
+const USE_MINIO = (process.env.USE_MINIO || 'false').toLowerCase() === 'true';
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT || 'localhost';
+const MINIO_PORT = parseInt(process.env.MINIO_PORT || '9000', 10);
+const MINIO_USE_SSL = (process.env.MINIO_USE_SSL || 'false').toLowerCase() === 'true';
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || 'minioadmin';
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'minioadmin';
+const MINIO_BUCKET = process.env.MINIO_BUCKET || 'events';
+
+let minioClient = null;
+
+async function ensureBucket() {
+  if (!USE_MINIO) return;
+  minioClient = new Minio.Client({ endPoint: MINIO_ENDPOINT, port: MINIO_PORT, useSSL: MINIO_USE_SSL, accessKey: MINIO_ACCESS_KEY, secretKey: MINIO_SECRET_KEY });
+  const exists = await minioClient.bucketExists(MINIO_BUCKET).catch(() => false);
+  if (!exists) await minioClient.makeBucket(MINIO_BUCKET, 'us-east-1');
+}
 
 function shardFor(key) {
   let h = 0;
@@ -17,6 +35,7 @@ async function main() {
   const ch = await conn.createChannel();
   const ex = 'events';
   await ch.assertExchange(ex, 'direct', { durable: true });
+  await ensureBucket();
 
   // declare shard queues and bindings (idempotent)
   for (let i = 0; i < NUM_SHARDS; i++) {
@@ -57,6 +76,14 @@ async function main() {
       rateType: 'standard',
       idempotencyKey
     };
+    // optionally store a large blob in MinIO and attach reference URL
+    if (USE_MINIO && minioClient) {
+      const key = `timesheets/${timesheetId}/${eventId}.json`;
+      const blob = JSON.stringify({ note: 'large-payload', filler: 'x'.repeat(128 * 1024) });
+      await minioClient.putObject(MINIO_BUCKET, key, blob, { 'Content-Type': 'application/json' });
+      const url = `${MINIO_USE_SSL ? 'https' : 'http'}://${MINIO_ENDPOINT}:${MINIO_PORT}/${MINIO_BUCKET}/${key}`;
+      payload.attachmentUrl = url;
+    }
     const shard = shardFor(timesheetId);
     const ok = ch.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(payload)), {
       contentType: 'application/json',
@@ -72,4 +99,3 @@ main().catch((e) => {
   console.error('[producer] error', e);
   process.exit(1);
 });
-

--- a/poc/event-backbone/local/producer/package.json
+++ b/poc/event-backbone/local/producer/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "amqplib": "^0.10.3",
-    "nanoid": "^5.0.7"
+    "nanoid": "^5.0.7",
+    "minio": "^8.0.1"
   }
 }
-


### PR DESCRIPTION
Enhance local Docker PoC with:

- MinIO service and optional producer uploads (attachmentUrl in events)
- E2E latency logging in consumer (occurredAt→processed)
- README updates and compose env vars

Helps exercise large-payload reference pattern and collect metrics locally before/alongside AWS/GCP PoCs.