### PR TITLE
Local PoC: add pm-service (publisher) and fi-service (consumer+API)

### DIFF
--- a/poc/event-backbone/local/README.md
+++ b/poc/event-backbone/local/README.md
@@ -36,7 +36,7 @@ docker compose up --build
 - 再送（同一Idempotency-Key）→重複抑止（skip）
 - 同一timesheetId→同一shard→コンシューマ単一で順序維持
 - FAIL_RATE>0 でDLQへ退避→手動でリドライブ（管理画面 or rabbitmqadmin）
- - MinIO使用時: コンソール http://localhost:9001 でオブジェクト（eventsバケット）を確認
+- MinIO使用時: コンソール http://localhost:9001 でオブジェクト（eventsバケット）を確認
 
 終了
 ```
@@ -50,3 +50,13 @@ docker compose down -v
 計測（レイテンシ）
 - Consumerは `occurredAt` と処理完了時刻からE2Eレイテンシを算出してログ出力（ms）。
 - ログから集計して `poc/event-backbone/metrics.md` に転記してください。
+
+API（サービス間連携の簡易テスト）
+- PMサービス（送信）: `POST http://localhost:3001/timesheets/approve`
+  - body例: `{ "timesheetId": "TS-001", "hours": 7.5, "note": "optional large note" }`
+  - ヘッダ: `Idempotency-Key: <uuid>`（省略時は自動生成）
+  - 応答: `{ accepted: true, eventId, shard }`
+
+- FIサービス（参照）:
+  - `GET http://localhost:3002/invoices` → 直近の請求ドラフト一覧
+  - `GET http://localhost:3002/invoices/{id}` → 個別取得

--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -52,3 +52,35 @@ services:
     depends_on:
       - rabbitmq
       - redis
+
+  pm-service:
+    build: ./services/pm-service
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - USE_MINIO=${USE_MINIO:-false}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio}
+      - MINIO_PORT=${MINIO_PORT:-9000}
+      - MINIO_USE_SSL=${MINIO_USE_SSL:-false}
+      - MINIO_ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}
+      - MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD:-minioadmin}
+      - MINIO_BUCKET=${MINIO_BUCKET:-events}
+      - PORT=3001
+    ports:
+      - "3001:3001"
+    depends_on:
+      - rabbitmq
+      - minio
+
+  fi-service:
+    build: ./services/fi-service
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - REDIS_URL=redis://redis:6379
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - PORT=3002
+    ports:
+      - "3002:3002"
+    depends_on:
+      - rabbitmq
+      - redis

--- a/poc/event-backbone/local/services/fi-service/Dockerfile
+++ b/poc/event-backbone/local/services/fi-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+COPY index.js ./
+EXPOSE 3002
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/services/fi-service/index.js
+++ b/poc/event-backbone/local/services/fi-service/index.js
@@ -1,0 +1,86 @@
+import amqp from 'amqplib';
+import Redis from 'ioredis';
+import express from 'express';
+
+const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@rabbitmq:5672';
+const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
+const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
+const PORT = parseInt(process.env.PORT || '3002', 10);
+
+function storeKey(invoiceId) { return `invoice:${invoiceId}`; }
+
+async function processMessage(redis, msg) {
+  const content = JSON.parse(msg.content.toString());
+  const key = content.idempotencyKey || (msg.properties.headers?.idempotencyKey);
+  if (!key) return { status: 'error', reason: 'no-idempotency-key' };
+  const ok = await redis.set(`idemp:${key}`, '1', 'NX', 'EX', 60 * 60);
+  if (ok === null) {
+    return { status: 'duplicate' };
+  }
+  const invoiceId = `INV-${content.timesheetId}-${Date.now()}`;
+  const now = Date.now();
+  let latencyMs = null;
+  try { latencyMs = now - new Date(content.occurredAt).getTime(); } catch (_) {}
+  const invoice = {
+    invoiceId,
+    timesheetId: content.timesheetId,
+    projectId: content.projectId,
+    employeeId: content.employeeId,
+    amount: Math.round((content.hours || 0) * 10000),
+    currency: 'JPY',
+    createdAt: new Date(now).toISOString(),
+    latencyMs,
+    attachmentUrl: content.attachmentUrl || null
+  };
+  await redis.hset(storeKey(invoiceId), invoice);
+  await redis.lpush('invoices', invoiceId);
+  console.log(`[fi-service] invoice ${invoiceId} created (ts=${content.timesheetId}) latency=${latencyMs}ms`);
+  return { status: 'ok', invoiceId };
+}
+
+async function consume(redis) {
+  const conn = await amqp.connect(AMQP_URL);
+  const ex = 'events';
+  for (let i = 0; i < NUM_SHARDS; i++) {
+    const ch = await conn.createChannel();
+    await ch.prefetch(1);
+    await ch.assertExchange(ex, 'direct', { durable: true });
+    const q = `shard.${i}`;
+    await ch.assertQueue(q, { durable: true, deadLetterExchange: 'dlx', deadLetterRoutingKey: q + '.dead' });
+    await ch.bindQueue(q, ex, q);
+    ch.consume(q, async (msg) => {
+      if (!msg) return;
+      try {
+        const res = await processMessage(redis, msg);
+        if (res.status === 'ok' || res.status === 'duplicate') ch.ack(msg); else ch.reject(msg, false);
+      } catch (e) {
+        console.warn('[fi-service] error:', e.message);
+        ch.reject(msg, false);
+      }
+    });
+  }
+}
+
+async function main() {
+  const redis = new Redis(REDIS_URL);
+  consume(redis).catch((e) => { console.error('[fi-service] consume error', e); process.exit(1); });
+
+  const app = express();
+  app.get('/health', (_req, res) => res.json({ ok: true }));
+  app.get('/invoices', async (_req, res) => {
+    const ids = await redis.lrange('invoices', 0, 99);
+    const multi = redis.multi();
+    ids.forEach(id => multi.hgetall(storeKey(id)));
+    const rows = await multi.exec();
+    res.json(rows.map(([, v]) => v).filter(Boolean));
+  });
+  app.get('/invoices/:id', async (req, res) => {
+    const row = await redis.hgetall(storeKey(req.params.id));
+    if (!row || !row.invoiceId) return res.status(404).json({ error: 'not found' });
+    res.json(row);
+  });
+  app.listen(PORT, () => console.log(`[fi-service] listening on :${PORT}`));
+}
+
+main().catch((e) => { console.error('[fi-service] fatal', e); process.exit(1); });
+

--- a/poc/event-backbone/local/services/fi-service/package.json
+++ b/poc/event-backbone/local/services/fi-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fi-service",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "amqplib": "^0.10.3",
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1"
+  }
+}
+

--- a/poc/event-backbone/local/services/pm-service/Dockerfile
+++ b/poc/event-backbone/local/services/pm-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+COPY index.js ./
+EXPOSE 3001
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/services/pm-service/index.js
+++ b/poc/event-backbone/local/services/pm-service/index.js
@@ -1,0 +1,96 @@
+import express from 'express';
+import amqp from 'amqplib';
+import { nanoid } from 'nanoid';
+import Minio from 'minio';
+
+const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@rabbitmq:5672';
+const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
+const PORT = parseInt(process.env.PORT || '3001', 10);
+const USE_MINIO = (process.env.USE_MINIO || 'false').toLowerCase() === 'true';
+
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT || 'minio';
+const MINIO_PORT = parseInt(process.env.MINIO_PORT || '9000', 10);
+const MINIO_USE_SSL = (process.env.MINIO_USE_SSL || 'false').toLowerCase() === 'true';
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || 'minioadmin';
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || 'minioadmin';
+const MINIO_BUCKET = process.env.MINIO_BUCKET || 'events';
+
+function shardFor(key) {
+  let h = 0;
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+  return h % NUM_SHARDS;
+}
+
+async function setupRabbit() {
+  const conn = await amqp.connect(AMQP_URL);
+  const ch = await conn.createChannel();
+  const ex = 'events';
+  await ch.assertExchange(ex, 'direct', { durable: true });
+  for (let i = 0; i < NUM_SHARDS; i++) {
+    const q = `shard.${i}`;
+    await ch.assertQueue(q, { durable: true, deadLetterExchange: 'dlx', deadLetterRoutingKey: q + '.dead' });
+    await ch.bindQueue(q, ex, `shard.${i}`);
+    await ch.assertExchange('dlx', 'direct', { durable: true });
+    await ch.assertQueue(q + '.dead', { durable: true });
+    await ch.bindQueue(q + '.dead', 'dlx', q + '.dead');
+  }
+  return { conn, ch };
+}
+
+async function ensureBucket(minioClient) {
+  if (!USE_MINIO) return;
+  const exists = await minioClient.bucketExists(MINIO_BUCKET).catch(() => false);
+  if (!exists) await minioClient.makeBucket(MINIO_BUCKET, 'us-east-1');
+}
+
+async function main() {
+  const app = express();
+  app.use(express.json({ limit: '2mb' }));
+
+  const { conn, ch } = await setupRabbit();
+  const minioClient = new Minio.Client({ endPoint: MINIO_ENDPOINT, port: MINIO_PORT, useSSL: MINIO_USE_SSL, accessKey: MINIO_ACCESS_KEY, secretKey: MINIO_SECRET_KEY });
+  if (USE_MINIO) await ensureBucket(minioClient);
+
+  app.get('/health', (_req, res) => res.json({ ok: true }));
+
+  // approve a timesheet and publish event
+  app.post('/timesheets/approve', async (req, res) => {
+    try {
+      const { timesheetId, employeeId = 'E-001', projectId = 'P-001', hours = 8, rateType = 'standard', note } = req.body || {};
+      if (!timesheetId) return res.status(400).json({ error: 'timesheetId required' });
+      const idempotencyKey = req.header('Idempotency-Key') || nanoid();
+      const eventId = nanoid();
+      const payload = {
+        eventId,
+        occurredAt: new Date().toISOString(),
+        tenantId: 'demo',
+        timesheetId,
+        employeeId,
+        projectId,
+        approvedBy: 'M-API',
+        hours,
+        rateType,
+        idempotencyKey
+      };
+      if (USE_MINIO && note) {
+        const key = `timesheets/${timesheetId}/${eventId}.json`;
+        await minioClient.putObject(MINIO_BUCKET, key, JSON.stringify({ note }), { 'Content-Type': 'application/json' });
+        payload.attachmentUrl = `${MINIO_USE_SSL ? 'https' : 'http'}://${MINIO_ENDPOINT}:${MINIO_PORT}/${MINIO_BUCKET}/${key}`;
+      }
+      const shard = shardFor(timesheetId);
+      ch.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(payload)), {
+        contentType: 'application/json', messageId: eventId, headers: { idempotencyKey, timesheetId }
+      });
+      res.status(202).json({ accepted: true, eventId, shard });
+    } catch (e) {
+      console.error('[pm-service] error', e);
+      res.status(500).json({ error: 'internal' });
+    }
+  });
+
+  app.listen(PORT, () => console.log(`[pm-service] listening on :${PORT}`));
+  process.on('SIGINT', () => conn.close().finally(() => process.exit(0)));
+}
+
+main().catch((e) => { console.error('[pm-service] fatal', e); process.exit(1); });
+

--- a/poc/event-backbone/local/services/pm-service/package.json
+++ b/poc/event-backbone/local/services/pm-service/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pm-service",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "amqplib": "^0.10.3",
+    "express": "^4.19.2",
+    "minio": "^8.0.1",
+    "nanoid": "^5.0.7"
+  }
+}
+


### PR DESCRIPTION
Extend local event backbone PoC with two services:\n\n- pm-service: HTTP API to approve timesheets, publishes events (optional MinIO attachment)\n- fi-service: consumes events with ordering+idempotency, stores invoice drafts in Redis, exposes /invoices API\n\nThis builds out a more realistic end-to-end flow for offline development and demo.