### PR TITLE
Local PoC: add sales→credit→pm→fi business flow

### DIFF
--- a/poc/event-backbone/local/README.md
+++ b/poc/event-backbone/local/README.md
@@ -60,3 +60,12 @@ API（サービス間連携の簡易テスト）
 - FIサービス（参照）:
   - `GET http://localhost:3002/invoices` → 直近の請求ドラフト一覧
   - `GET http://localhost:3002/invoices/{id}` → 個別取得
+
+- Salesサービス（受注確定）: `POST http://localhost:3003/sales/orders/confirm`
+  - body例: `{ "orderId": "SO-1001", "customerId": "C-001", "amount": 500000 }`
+  - 応答: `{ accepted: true, eventId, shard }`
+
+- Creditサービス（自動処理）: 環境変数 `CREDIT_LIMIT`（デフォルト 1,000,000）以下なら `sales.credit.approved` を発行
+
+- FIサービス（受注ステータス）:
+  - `GET http://localhost:3002/orders/{orderId}/status` → `credit`（approved/rejected/unknown）と `projectId`

--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -84,3 +84,23 @@ services:
     depends_on:
       - rabbitmq
       - redis
+
+  sales-service:
+    build: ./services/sales-service
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - PORT=3003
+    ports:
+      - "3003:3003"
+    depends_on:
+      - rabbitmq
+
+  credit-service:
+    build: ./services/credit-service
+    environment:
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - CREDIT_LIMIT=${CREDIT_LIMIT:-1000000}
+    depends_on:
+      - rabbitmq

--- a/poc/event-backbone/local/services/credit-service/Dockerfile
+++ b/poc/event-backbone/local/services/credit-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+COPY index.js ./
+EXPOSE 3004
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/services/credit-service/index.js
+++ b/poc/event-backbone/local/services/credit-service/index.js
@@ -1,0 +1,48 @@
+import amqp from 'amqplib';
+
+const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@rabbitmq:5672';
+const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
+const CREDIT_LIMIT = parseInt(process.env.CREDIT_LIMIT || '1000000', 10);
+
+async function main() {
+  const conn = await amqp.connect(AMQP_URL);
+  const ex = 'events';
+  for (let i = 0; i < NUM_SHARDS; i++) {
+    const ch = await conn.createChannel();
+    await ch.prefetch(1);
+    await ch.assertExchange(ex, 'direct', { durable: true });
+    const q = `shard.${i}`;
+    await ch.assertQueue(q, { durable: true, deadLetterExchange: 'dlx', deadLetterRoutingKey: q + '.dead' });
+    await ch.bindQueue(q, ex, q);
+    ch.consume(q, async (msg) => {
+      if (!msg) return;
+      try {
+        const payload = JSON.parse(msg.content.toString());
+        if (payload.eventType === 'sales.order.confirmed') {
+          const approved = (payload.amount || 0) <= CREDIT_LIMIT;
+          const event = {
+            eventId: msg.properties.messageId + '.credit',
+            occurredAt: new Date().toISOString(),
+            eventType: approved ? 'sales.credit.approved' : 'sales.credit.rejected',
+            tenantId: payload.tenantId,
+            orderId: payload.orderId,
+            customerId: payload.customerId,
+            amount: payload.amount
+          };
+          const shard = i; // same shard ensures ordering per orderId
+          ch.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(event)), {
+            contentType: 'application/json', messageId: event.eventId, headers: { orderId: payload.orderId }
+          });
+        }
+        ch.ack(msg);
+      } catch (e) {
+        console.warn('[credit-service] error', e.message);
+        ch.reject(msg, false);
+      }
+    });
+  }
+  console.log(`[credit-service] started with CREDIT_LIMIT=${CREDIT_LIMIT}`);
+}
+
+main().catch((e) => { console.error('[credit-service] fatal', e); process.exit(1); });
+

--- a/poc/event-backbone/local/services/credit-service/package.json
+++ b/poc/event-backbone/local/services/credit-service/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "credit-service",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "amqplib": "^0.10.3"
+  }
+}
+

--- a/poc/event-backbone/local/services/sales-service/Dockerfile
+++ b/poc/event-backbone/local/services/sales-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+COPY index.js ./
+EXPOSE 3003
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/services/sales-service/index.js
+++ b/poc/event-backbone/local/services/sales-service/index.js
@@ -1,0 +1,71 @@
+import express from 'express';
+import amqp from 'amqplib';
+import { nanoid } from 'nanoid';
+
+const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@rabbitmq:5672';
+const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
+const PORT = parseInt(process.env.PORT || '3003', 10);
+
+function shardFor(key) {
+  let h = 0;
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+  return h % NUM_SHARDS;
+}
+
+async function setupRabbit() {
+  const conn = await amqp.connect(AMQP_URL);
+  const ch = await conn.createChannel();
+  const ex = 'events';
+  await ch.assertExchange(ex, 'direct', { durable: true });
+  for (let i = 0; i < NUM_SHARDS; i++) {
+    const q = `shard.${i}`;
+    await ch.assertQueue(q, { durable: true, deadLetterExchange: 'dlx', deadLetterRoutingKey: q + '.dead' });
+    await ch.bindQueue(q, ex, `shard.${i}`);
+    await ch.assertExchange('dlx', 'direct', { durable: true });
+    await ch.assertQueue(q + '.dead', { durable: true });
+    await ch.bindQueue(q + '.dead', 'dlx', q + '.dead');
+  }
+  return { conn, ch };
+}
+
+async function main() {
+  const { conn, ch } = await setupRabbit();
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+
+  app.get('/health', (_req, res) => res.json({ ok: true }));
+
+  app.post('/sales/orders/confirm', async (req, res) => {
+    try {
+      const { orderId, customerId, amount } = req.body || {};
+      if (!orderId || !customerId || typeof amount !== 'number') {
+        return res.status(400).json({ error: 'orderId, customerId, amount required' });
+      }
+      const eventId = nanoid();
+      const idempotencyKey = req.header('Idempotency-Key') || `order-${orderId}`;
+      const payload = {
+        eventId,
+        occurredAt: new Date().toISOString(),
+        eventType: 'sales.order.confirmed',
+        tenantId: 'demo',
+        orderId,
+        customerId,
+        amount
+      };
+      const shard = shardFor(orderId);
+      ch.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(payload)), {
+        contentType: 'application/json', messageId: eventId, headers: { idempotencyKey, orderId }
+      });
+      res.status(202).json({ accepted: true, eventId, shard });
+    } catch (e) {
+      console.error('[sales-service] error', e);
+      res.status(500).json({ error: 'internal' });
+    }
+  });
+
+  app.listen(PORT, () => console.log(`[sales-service] listening on :${PORT}`));
+  process.on('SIGINT', () => conn.close().finally(() => process.exit(0)));
+}
+
+main().catch((e) => { console.error('[sales-service] fatal', e); process.exit(1); });
+

--- a/poc/event-backbone/local/services/sales-service/package.json
+++ b/poc/event-backbone/local/services/sales-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sales-service",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "amqplib": "^0.10.3",
+    "express": "^4.19.2",
+    "nanoid": "^5.0.7"
+  }
+}
+


### PR DESCRIPTION
Extend local event backbone with a second business flow:\n\n- sales-service: POST /sales/orders/confirm → sales.order.confirmed\n- credit-service: consumes order→ sales.credit.approved|rejected (CREDIT_LIMIT)\n- pm-service: consumes order→ pm.project.created (maps order→project)\n- fi-service: tracks credit status and order→project mapping; adds /orders/{id}/status\n\nKeeps ordering/idempotency model and uses same shard queues. Docs updated in local README.