### PR TITLE
Local PoC: FI credit guard, failure/delay injection, budget allocation events

### DIFF
--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -78,6 +78,9 @@ services:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - REDIS_URL=redis://redis:6379
       - NUM_SHARDS=${NUM_SHARDS:-4}
+      - INJECT_DELAY_MS=${INJECT_DELAY_MS:-0}
+      - INJECT_FAIL_RATE=${INJECT_FAIL_RATE:-0.0}
+      - FI_ENFORCE_CREDIT=${FI_ENFORCE_CREDIT:-true}
       - PORT=3002
     ports:
       - "3002:3002"


### PR DESCRIPTION
Enhance FI service with:\n\n- Credit guard: timesheet→invoice skips if order credit not approved (when project→order mapping exists)\n- Failure/Delay injection via env (INJECT_FAIL_RATE, INJECT_DELAY_MS) for resilience testing\n- Budget allocation emission: when both credit approved and project created for an order, emit fi.budget.allocated once\n\nCompose updated with new env vars.