### PR TITLE
Local PoC: add metrics-dashboard (summary API + simple UI)

### DIFF
--- a/poc/event-backbone/local/README.md
+++ b/poc/event-backbone/local/README.md
@@ -31,6 +31,7 @@ docker compose up --build
 - Consumerログ: invoice生成（冪等時はskip表示）
 - RabbitMQ管理画面: http://localhost:15672 （user: guest / pass: guest）
 - Redis: idempotencyキーを格納（`idemp:{key}`）
+- メトリクスダッシュボード: http://localhost:3005 （E2Eレイテンシ、件数の簡易表示）
 
 想定確認
 - 再送（同一Idempotency-Key）→重複抑止（skip）

--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -107,3 +107,13 @@ services:
       - CREDIT_LIMIT=${CREDIT_LIMIT:-1000000}
     depends_on:
       - rabbitmq
+
+  metrics-dashboard:
+    build: ./services/metrics-dashboard
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - PORT=3005
+    ports:
+      - "3005:3005"
+    depends_on:
+      - redis

--- a/poc/event-backbone/local/services/metrics-dashboard/Dockerfile
+++ b/poc/event-backbone/local/services/metrics-dashboard/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+COPY index.js public/ ./
+EXPOSE 3005
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/services/metrics-dashboard/index.js
+++ b/poc/event-backbone/local/services/metrics-dashboard/index.js
@@ -1,0 +1,72 @@
+import express from 'express';
+import Redis from 'ioredis';
+
+const PORT = parseInt(process.env.PORT || '3005', 10);
+const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
+const redis = new Redis(REDIS_URL);
+
+function percentile(arr, p) {
+  if (!arr.length) return null;
+  const a = [...arr].sort((x, y) => x - y);
+  const idx = Math.min(a.length - 1, Math.max(0, Math.ceil((p / 100) * a.length) - 1));
+  return a[idx];
+}
+
+async function fetchInvoices(limit = 500) {
+  const ids = await redis.lrange('invoices', 0, limit - 1);
+  const multi = redis.multi();
+  ids.forEach((id) => multi.hgetall(`invoice:${id}`));
+  const rows = await multi.exec();
+  return rows.map(([, v]) => v).filter(Boolean);
+}
+
+async function countByPattern(pattern) {
+  let cursor = '0';
+  let count = 0;
+  do {
+    const res = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 1000);
+    cursor = res[0];
+    count += res[1].length;
+  } while (cursor !== '0');
+  return count;
+}
+
+async function gatherSummary() {
+  const invoices = await fetchInvoices();
+  const latencies = invoices
+    .map((i) => Number(i.latencyMs))
+    .filter((n) => Number.isFinite(n) && n >= 0);
+  const latency = {
+    count: latencies.length,
+    avg: latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null,
+    p50: percentile(latencies, 50),
+    p95: percentile(latencies, 95),
+    p99: percentile(latencies, 99)
+  };
+  // credit status counts (approx via SCAN)
+  const creditApproved = await countByPattern('order:*:credit');
+  const budgetAllocated = await countByPattern('order:*:budget_emitted');
+  return {
+    invoicesTotal: await redis.llen('invoices'),
+    latency,
+    orders: {
+      creditKeys: creditApproved,
+      budgetAllocatedKeys: budgetAllocated
+    },
+    timestamp: new Date().toISOString()
+  };
+}
+
+const app = express();
+app.use(express.static('public'));
+app.get('/metrics/summary', async (_req, res) => {
+  try {
+    res.json(await gatherSummary());
+  } catch (e) {
+    console.error('[metrics] error', e);
+    res.status(500).json({ error: 'metrics_failed' });
+  }
+});
+
+app.listen(PORT, () => console.log(`[metrics-dashboard] listening on :${PORT}`));
+

--- a/poc/event-backbone/local/services/metrics-dashboard/package.json
+++ b/poc/event-backbone/local/services/metrics-dashboard/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "metrics-dashboard",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1"
+  }
+}
+

--- a/poc/event-backbone/local/services/metrics-dashboard/public/index.html
+++ b/poc/event-backbone/local/services/metrics-dashboard/public/index.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Local PoC Metrics</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 20px; }
+      .card { border: 1px solid #ddd; padding: 12px; margin: 12px 0; border-radius: 8px; }
+      .row { display: flex; gap: 16px; }
+      .row .card { flex: 1; }
+      .muted { color: #666; }
+    </style>
+  </head>
+  <body>
+    <h1>Local Event Backbone Metrics</h1>
+    <div id="status" class="muted">Loading...</div>
+    <div class="row">
+      <div class="card">
+        <h3>Invoices</h3>
+        <div>Total: <span id="inv-total">-</span></div>
+      </div>
+      <div class="card">
+        <h3>Latency (ms)</h3>
+        <div>Count: <span id="lat-count">-</span></div>
+        <div>Avg: <span id="lat-avg">-</span></div>
+        <div>P50: <span id="lat-p50">-</span></div>
+        <div>P95: <span id="lat-p95">-</span></div>
+        <div>P99: <span id="lat-p99">-</span></div>
+      </div>
+      <div class="card">
+        <h3>Orders</h3>
+        <div>Credit keys: <span id="ord-cred">-</span></div>
+        <div>Budget allocated keys: <span id="ord-budg">-</span></div>
+      </div>
+    </div>
+    <script>
+      async function load() {
+        try {
+          const res = await fetch('/metrics/summary');
+          const j = await res.json();
+          document.getElementById('status').textContent = `Last update: ${j.timestamp}`;
+          document.getElementById('inv-total').textContent = j.invoicesTotal;
+          document.getElementById('lat-count').textContent = j.latency.count ?? '-';
+          document.getElementById('lat-avg').textContent = j.latency.avg ?? '-';
+          document.getElementById('lat-p50').textContent = j.latency.p50 ?? '-';
+          document.getElementById('lat-p95').textContent = j.latency.p95 ?? '-';
+          document.getElementById('lat-p99').textContent = j.latency.p99 ?? '-';
+          document.getElementById('ord-cred').textContent = j.orders.creditKeys;
+          document.getElementById('ord-budg').textContent = j.orders.budgetAllocatedKeys;
+        } catch (e) {
+          document.getElementById('status').textContent = 'Error loading metrics';
+        }
+      }
+      load();
+      setInterval(load, 5000);
+    </script>
+  </body>
+  </html>
+


### PR DESCRIPTION
Add a lightweight metrics dashboard for the local PoC:\n\n- /metrics/summary: invoices total, latency (avg/p50/p95/p99), credit/budget key counts\n- Static UI at / (auto-refresh every 5s)\n\nBacked by Redis keys created by fi-service. Accessible at http://localhost:3005. README updated.