### PR TITLE
Local PoC: contract renewal/reminder + credit override/onhold handling

### DIFF
--- a/poc/event-backbone/local/README.md
+++ b/poc/event-backbone/local/README.md
@@ -67,6 +67,13 @@ API（サービス間連携の簡易テスト）
   - 応答: `{ accepted: true, eventId, shard }`
 
 - Creditサービス（自動処理）: 環境変数 `CREDIT_LIMIT`（デフォルト 1,000,000）以下なら `sales.credit.approved` を発行
+  - 手動オーバーライド: `POST http://localhost:3004/credit/override` body例 `{ "orderId": "SO-1001", "amount": 800000, "approver": "manager" }`
 
 - FIサービス（受注ステータス）:
   - `GET http://localhost:3002/orders/{orderId}/status` → `credit`（approved/rejected/unknown）と `projectId`
+
+- Contractサービス（契約・更新）:
+  - 追加/更新: `POST http://localhost:3006/contracts` body例 `{ "contractId": "CT-2024-001", "customerId": "C-001", "renewalDate": "2025-09-01", "amount": 1200000 }`
+  - 一覧: `GET http://localhost:3006/contracts`
+  - リマインド発火: `POST http://localhost:3006/contracts/reminders/trigger` body例 `{ "days": 60 }` → `ckm.contract.renewal.reminder` 発行
+  - 更新: `POST http://localhost:3006/contracts/{id}/renew` body例 `{ "newDate": "2026-09-01" }` → `ckm.contract.renewed` 発行

--- a/poc/event-backbone/local/docker-compose.yml
+++ b/poc/event-backbone/local/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - NUM_SHARDS=${NUM_SHARDS:-4}
       - CREDIT_LIMIT=${CREDIT_LIMIT:-1000000}
+      - PORT=3004
     depends_on:
       - rabbitmq
 
@@ -117,3 +118,16 @@ services:
       - "3005:3005"
     depends_on:
       - redis
+
+  contract-service:
+    build: ./services/contract-service
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - NUM_SHARDS=${NUM_SHARDS:-4}
+      - PORT=3006
+    ports:
+      - "3006:3006"
+    depends_on:
+      - redis
+      - rabbitmq

--- a/poc/event-backbone/local/services/contract-service/Dockerfile
+++ b/poc/event-backbone/local/services/contract-service/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm i --omit=dev
+COPY index.js ./
+EXPOSE 3006
+CMD ["node", "index.js"]
+

--- a/poc/event-backbone/local/services/contract-service/index.js
+++ b/poc/event-backbone/local/services/contract-service/index.js
@@ -1,0 +1,95 @@
+import express from 'express';
+import Redis from 'ioredis';
+import amqp from 'amqplib';
+
+const PORT = parseInt(process.env.PORT || '3006', 10);
+const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
+const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@rabbitmq:5672';
+const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
+
+const redis = new Redis(REDIS_URL);
+
+function shardOf(key) {
+  let h = 0; for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0; return h % NUM_SHARDS;
+}
+
+async function main() {
+  const conn = await amqp.connect(AMQP_URL);
+  const pub = await conn.createChannel();
+  await pub.assertExchange('events', 'direct', { durable: true });
+
+  const app = express();
+  app.use(express.json());
+
+  // Create/Update contract
+  app.post('/contracts', async (req, res) => {
+    const { contractId, customerId, renewalDate, amount = 0 } = req.body || {};
+    if (!contractId || !customerId || !renewalDate) return res.status(400).json({ error: 'contractId, customerId, renewalDate required' });
+    await redis.hset(`contract:${contractId}`, { customerId, renewalDate, amount });
+    await redis.sadd('contracts', contractId);
+    res.status(201).json({ ok: true });
+  });
+
+  // Trigger reminders for contracts expiring within N days
+  app.post('/contracts/reminders/trigger', async (req, res) => {
+    const days = parseInt((req.body && req.body.days) || '30', 10);
+    const now = Date.now();
+    const cutoff = now + days * 24 * 60 * 60 * 1000;
+    const ids = await redis.smembers('contracts');
+    let sent = 0;
+    for (const id of ids) {
+      const h = await redis.hgetall(`contract:${id}`);
+      if (!h || !h.renewalDate) continue;
+      const due = Date.parse(h.renewalDate);
+      if (isNaN(due)) continue;
+      if (due <= cutoff) {
+        const evt = {
+          eventId: `contract-reminder-${id}-${Date.now()}`,
+          occurredAt: new Date().toISOString(),
+          eventType: 'ckm.contract.renewal.reminder',
+          contractId: id,
+          customerId: h.customerId,
+          renewalDate: h.renewalDate
+        };
+        const shard = shardOf(id);
+        pub.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(evt)), { contentType: 'application/json', messageId: evt.eventId });
+        sent++;
+      }
+    }
+    res.json({ sent });
+  });
+
+  // Renew a contract now (manual action)
+  app.post('/contracts/:id/renew', async (req, res) => {
+    const id = req.params.id;
+    const { newDate } = req.body || {};
+    if (!newDate) return res.status(400).json({ error: 'newDate required' });
+    const exists = await redis.exists(`contract:${id}`);
+    if (!exists) return res.status(404).json({ error: 'not_found' });
+    await redis.hset(`contract:${id}`, { renewalDate: newDate });
+    const evt = {
+      eventId: `contract-renewed-${id}-${Date.now()}`,
+      occurredAt: new Date().toISOString(),
+      eventType: 'ckm.contract.renewed',
+      contractId: id,
+      renewalDate: newDate
+    };
+    const shard = shardOf(id);
+    pub.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(evt)), { contentType: 'application/json', messageId: evt.eventId });
+    res.json({ ok: true, eventId: evt.eventId });
+  });
+
+  app.get('/contracts', async (_req, res) => {
+    const ids = await redis.smembers('contracts');
+    const multi = redis.multi();
+    ids.forEach((id) => multi.hgetall(`contract:${id}`));
+    const rows = await multi.exec();
+    res.json(ids.map((id, idx) => ({ contractId: id, ...rows[idx][1] })));
+  });
+
+  app.get('/health', (_req, res) => res.json({ ok: true }));
+  app.listen(PORT, () => console.log(`[contract-service] listening on :${PORT}`));
+}
+
+main().catch((e) => { console.error('[contract-service] fatal', e); process.exit(1); });
+

--- a/poc/event-backbone/local/services/contract-service/package.json
+++ b/poc/event-backbone/local/services/contract-service/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "credit-service",
+  "name": "contract-service",
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
     "amqplib": "^0.10.3",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1"
   }
 }
+

--- a/poc/event-backbone/local/services/credit-service/index.js
+++ b/poc/event-backbone/local/services/credit-service/index.js
@@ -1,12 +1,18 @@
 import amqp from 'amqplib';
+import express from 'express';
 
 const AMQP_URL = process.env.AMQP_URL || 'amqp://guest:guest@rabbitmq:5672';
 const NUM_SHARDS = parseInt(process.env.NUM_SHARDS || '4', 10);
 const CREDIT_LIMIT = parseInt(process.env.CREDIT_LIMIT || '1000000', 10);
+const PORT = parseInt(process.env.PORT || '3004', 10);
 
 async function main() {
   const conn = await amqp.connect(AMQP_URL);
   const ex = 'events';
+  const pub = await conn.createChannel();
+  await pub.assertExchange(ex, 'direct', { durable: true });
+
+  // Consumer for sales.order.confirmed
   for (let i = 0; i < NUM_SHARDS; i++) {
     const ch = await conn.createChannel();
     await ch.prefetch(1);
@@ -29,10 +35,15 @@ async function main() {
             customerId: payload.customerId,
             amount: payload.amount
           };
-          const shard = i; // same shard ensures ordering per orderId
-          ch.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(event)), {
+          pub.publish('events', `shard.${i}`, Buffer.from(JSON.stringify(event)), {
             contentType: 'application/json', messageId: event.eventId, headers: { orderId: payload.orderId }
           });
+          if (!approved) {
+            const onhold = { ...event, eventId: event.eventId + '.onhold', eventType: 'sales.credit.onhold' };
+            pub.publish('events', `shard.${i}`, Buffer.from(JSON.stringify(onhold)), {
+              contentType: 'application/json', messageId: onhold.eventId, headers: { orderId: payload.orderId }
+            });
+          }
         }
         ch.ack(msg);
       } catch (e) {
@@ -41,8 +52,36 @@ async function main() {
       }
     });
   }
-  console.log(`[credit-service] started with CREDIT_LIMIT=${CREDIT_LIMIT}`);
+
+  // Minimal override API
+  const app = express();
+  app.use(express.json());
+  app.post('/credit/override', async (req, res) => {
+    try {
+      const { orderId, customerId = 'unknown', amount = 0, approver = 'manager' } = req.body || {};
+      if (!orderId) return res.status(400).json({ error: 'orderId required' });
+      const event = {
+        eventId: `override-${orderId}-${Date.now()}`,
+        occurredAt: new Date().toISOString(),
+        eventType: 'sales.credit.override.approved',
+        tenantId: 'demo',
+        orderId,
+        customerId,
+        amount,
+        approver
+      };
+      // shard by orderId
+      let h = 0; for (let i = 0; i < orderId.length; i++) h = (h * 31 + orderId.charCodeAt(i)) >>> 0;
+      const shard = h % NUM_SHARDS;
+      pub.publish('events', `shard.${shard}`, Buffer.from(JSON.stringify(event)), { contentType: 'application/json', messageId: event.eventId });
+      res.status(202).json({ accepted: true, eventId: event.eventId, shard });
+    } catch (e) {
+      console.error('[credit-service] override error', e);
+      res.status(500).json({ error: 'internal' });
+    }
+  });
+  app.get('/health', (_req, res) => res.json({ ok: true }));
+  app.listen(PORT, () => console.log(`[credit-service] listening on :${PORT} (CREDIT_LIMIT=${CREDIT_LIMIT})`));
 }
 
 main().catch((e) => { console.error('[credit-service] fatal', e); process.exit(1); });
-


### PR DESCRIPTION
Extend local business flows with:\n\n- contract-service: create/list, renewal reminder trigger, manual renew (emits ckm.contract.renewal.reminder / ckm.contract.renewed)\n- credit-service: emits sales.credit.onhold when rejected; manual override API emits sales.credit.override.approved\n- fi-service: guards invoices until credit approved; retains existing timesheet→invoice path\n\nCompose and README updated with endpoints.