### PR TITLE
Local PoC: exception flows (credit revoked, project cancelled) + DLQ redrive

### DIFF
--- a/poc/event-backbone/local/services/metrics-dashboard/package.json
+++ b/poc/event-backbone/local/services/metrics-dashboard/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "express": "^4.19.2",
     "ioredis": "^5.4.1",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "amqplib": "^0.10.3"
   }
 }


### PR DESCRIPTION
- credit-service: add /credit/revoke → sales.credit.revoked\n- pm-service: add /projects/{id}/cancel → pm.project.cancelled\n- fi-service: handle both to unmap project and block billing\n- metrics-dashboard: add POST /ops/redrive to move messages from shard.*.dead back to shard.*\n\nHelps validate exception paths and recovery operations locally.