### PR TITLE
docs(openapi): standardize pagination for compliance search

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -29,8 +29,7 @@ paths:
         - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/TenantHeader'
-        - $ref: '#/components/parameters/PageLimit'
-        - $ref: '#/components/parameters/PageCursor'
+        
         - $ref: '#/components/parameters/Sort'
       responses:
         '200':


### PR DESCRIPTION
目的: ページング表現の統一をコンプライアンス検索にも適用します。

- GET /api/v1/compliance/invoices/search に Sort/Limit/Cursor を明示
- レスポンスを PaginatedComplianceInvoices に変更

関連: #36