### PR TITLE
feat(openapi): add GET /timesheets with standardized pagination

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -42,6 +42,25 @@ paths:
           $ref: '#/components/responses/Error'
 
   /api/v1/timesheets:
+    get:
+      tags: [timesheets]
+      summary: 工数一覧
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - $ref: '#/components/parameters/PageLimit'
+        - $ref: '#/components/parameters/PageCursor'
+        - $ref: '#/components/parameters/Sort'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedTimesheets'
+        default:
+          $ref: '#/components/responses/Error'
     post:
       tags: [timesheets]
       summary: 工数登録
@@ -273,6 +292,16 @@ components:
           type: string
           enum: [draft, submitted, approved, rejected]
       required: [user_id, project_id, work_date, hours]
+    PaginatedTimesheets:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TimesheetEntry'
+        next_cursor:
+          type: string
+      required: [items]
     ProfitResponse:
       type: object
       properties:

--- a/specs/apis/README.md
+++ b/specs/apis/README.md
@@ -7,6 +7,7 @@
 
 ## 代表エンドポイント例
 - `GET /api/v1/projects`
+- `GET /api/v1/timesheets`
 - `POST /api/v1/timesheets`
 - `GET /api/v1/projects/{id}/profit`（revenue, labor_cost, external_cost, overhead, gross_profit, progress_based_revenue）
 - `POST /api/v1/compliance/invoices`（電子取引保存: メタ+PDFアップロード）


### PR DESCRIPTION
目的: ページング標準をTimesheets一覧にも適用し、APIを拡充します。

- GET /api/v1/timesheets（PaginatedTimesheets, Sort/Limit/Cursor）
- specs/apis/README.md に一覧を追記

関連: #36, #38