### PR TITLE
docs(db): add status lookup tables and indexing guidelines

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -188,3 +188,16 @@ CREATE TABLE IF NOT EXISTS audit_logs (
 );
 CREATE INDEX IF NOT EXISTS idx_audit_tenant_time ON audit_logs(tenant_id, occurred_at DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_entity ON audit_logs(tenant_id, entity_type, entity_id);
+-- Status lookup tables (optional seed)
+CREATE TABLE IF NOT EXISTS task_statuses (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS timesheet_statuses (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS invoice_statuses (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);

--- a/specs/db-indexes.md
+++ b/specs/db-indexes.md
@@ -1,0 +1,11 @@
+# インデックス最適化（ドラフト)
+
+- projects: UNIQUE(tenant_id, code), INDEX(status), INDEX(client_id)
+- accounts: UNIQUE(tenant_id, code)
+- invoices: INDEX(account_id, issue_date), UNIQUE(tenant_id, invoice_number)
+- payments: INDEX(invoice_id, paid_on)
+- timesheets: INDEX(project_id, work_date), INDEX(user_id, work_date)
+- audit_logs: INDEX(tenant_id, occurred_at DESC), INDEX(tenant_id, entity_type, entity_id)
+
+後続でクエリプロファイルに基づき調整。
+


### PR DESCRIPTION
目的: ステータスのコード表（lookup）追加と、代表的なインデックス戦略を文書化します。

- db/schema.sql: task_statuses/timesheet_statuses/invoice_statuses 追加
- specs/db-indexes.md: インデックス最適化の指針