### PR TITLE
feat(openapi): add changes[] to AuditLog

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -495,7 +495,18 @@ components:
         entity_id: { type: string }
         ip: { type: string }
         user_agent: { type: string }
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditChange'
       required: [id, occurred_at, action]
+    AuditChange:
+      type: object
+      properties:
+        field: { type: string }
+        before: {}
+        after: {}
+      required: [field]
     PaginatedAuditLogs:
       type: object
       properties:


### PR DESCRIPTION
目的: 監査ログのレスポンスに changes 配列を追加し、差分情報を返せるようにします。

- AuditLog に changes[] を追加
- AuditChange スキーマを定義