### PR TITLE
feat(openapi): status-codes API (+ docs)

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -24,6 +24,8 @@ tags:
     description: 販売（見積/受注/請求連動）
   - name: procurement
     description: 購買（発注/検収/買掛）
+  - name: metadata
+    description: コード/マスタ/設定
 paths:
   /api/v1/projects:
     get:
@@ -242,6 +244,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedAuditLogs'
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/status-codes:
+    get:
+      tags: [metadata]
+      summary: ステータスコード取得
+      description: ドメイン別のステータスコード一覧を返す（task|timesheet|invoice）
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: domain
+          in: query
+          required: true
+          schema: { type: string, enum: [task, timesheet, invoice] }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/StatusCode' }
+                required: [items]
         default:
           $ref: '#/components/responses/Error'
 components:
@@ -549,6 +579,12 @@ components:
         before: {}
         after: {}
       required: [field]
+    StatusCode:
+      type: object
+      properties:
+        code: { type: string }
+        name: { type: string }
+      required: [code, name]
     PaginatedAuditLogs:
       type: object
       properties:

--- a/specs/status-codes.md
+++ b/specs/status-codes.md
@@ -1,0 +1,9 @@
+# ステータスコードAPI（ドラフト）
+
+- エンドポイント: `GET /api/v1/status-codes?domain=task|timesheet|invoice`
+- 目的: クライアントが列挙や表示名を動的に取得するための簡易メタデータAPI
+- レスポンス: `{ items: [{ code, name }] }`
+- データ源: DBのlookupテーブル（task_statuses / timesheet_statuses / invoice_statuses）
+- キャッシュ: 数分〜数時間のキャッシュ可（頻繁に変化しない）
+
+今後: ドメイン拡張や無効化フラグ、並び順などを追加検討。


### PR DESCRIPTION
目的: ドメイン別ステータスコード取得APIを追加し、利用方針を文書化します。

- GET /api/v1/status-codes?domain=task|timesheet|invoice
- schemas: StatusCode
- docs: specs/status-codes.md