### PR TITLE
feat(openapi): extend StatusCode with active/ordinal

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -585,6 +585,8 @@ components:
       properties:
         code: { type: string }
         name: { type: string }
+        active: { type: boolean, default: true }
+        ordinal: { type: integer, description: '表示順' }
       required: [code, name]
     PaginatedAuditLogs:
       type: object

--- a/specs/status-codes.md
+++ b/specs/status-codes.md
@@ -2,8 +2,8 @@
 
 - エンドポイント: `GET /api/v1/status-codes?domain=task|timesheet|invoice`
 - 目的: クライアントが列挙や表示名を動的に取得するための簡易メタデータAPI
-- レスポンス: `{ items: [{ code, name }] }`
+- レスポンス: `{ items: [{ code, name, active, ordinal }] }`
 - データ源: DBのlookupテーブル（task_statuses / timesheet_statuses / invoice_statuses）
 - キャッシュ: 数分〜数時間のキャッシュ可（頻繁に変化しない）
 
-今後: ドメイン拡張や無効化フラグ、並び順などを追加検討。
+今後: ドメイン拡張や無効化フラグ、並び順などを追加検討（active/ordinalは任意）。


### PR DESCRIPTION
目的: ステータスコードの表現を拡張し、active/ordinal を含めます。

- schemas.StatusCode に active(bool) / ordinal(int) を追加
- docs を更新