### PR TITLE
feat(openapi): extend status-codes domain enum

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -260,7 +260,7 @@ paths:
         - name: domain
           in: query
           required: true
-          schema: { type: string, enum: [task, timesheet, invoice] }
+          schema: { type: string, enum: [task, timesheet, invoice, sales_order, purchase_order, project] }
       responses:
         '200':
           description: OK

--- a/specs/status-codes.md
+++ b/specs/status-codes.md
@@ -1,6 +1,6 @@
 # ステータスコードAPI（ドラフト）
 
-- エンドポイント: `GET /api/v1/status-codes?domain=task|timesheet|invoice`
+- エンドポイント: `GET /api/v1/status-codes?domain=task|timesheet|invoice|sales_order|purchase_order|project`
 - 目的: クライアントが列挙や表示名を動的に取得するための簡易メタデータAPI
 - レスポンス: `{ items: [{ code, name, active, ordinal }] }`
 - データ源: DBのlookupテーブル（task_statuses / timesheet_statuses / invoice_statuses）


### PR DESCRIPTION
目的: status-codes API の domain を拡張（sales_order/purchase_order/project）します。