### PR TITLE
docs(links): rounding options (unit/mode)

### DIFF
--- a/specs/linking.md
+++ b/specs/linking.md
@@ -3,10 +3,13 @@
 ## 受注（SalesOrder）→ 請求（Invoice）
 - 行マッピング: SalesOrderLine → InvoiceLine（item_code/description/qty/unit_price）
 - 金額・税
-  - line_amount = qty × unit_price（丸め: 小数2桁、四捨五入）
+  - line_amount = qty × unit_price（丸めは可変、デフォルト: 小数2桁、四捨五入）
   - tax_rate は品目/契約/税区分の規則で決定（例: 10%, 0%）
   - invoice.total = Σ line_amount、invoice.tax_total = Σ (line_amount × tax_rate)
-  - 端数丸め: line単位で丸め、合計は行合算（契約要件で切替可能）
+  - 端数丸めオプション:
+    - 集計単位: `line`（行単位で丸めて合算）/ `document`（最終合計で丸め）
+    - 丸め方式: `half_up`（四捨五入）/ `half_even`（銀行丸め）/ `truncate`（切り捨て）
+    - 設定箇所: テナント設定 or 契約単位で上書き
 - タイミング: confirmed/fulfilled のいずれかでトリガ可能（運用定義）
 
 ## 発注（PurchaseOrder）→ 買掛（VendorBill）


### PR DESCRIPTION
目的: 行→請求の丸めオプション（集計単位/丸め方式/設定箇所）を明文化します。