### PR TITLE
chore(db): add status lookups (sales/purchase/project) + migrate plan

### DIFF
--- a/db/migrations/2025-09-11-status-lookups-extend.sql
+++ b/db/migrations/2025-09-11-status-lookups-extend.sql
@@ -1,0 +1,34 @@
+-- Create additional status lookup tables for sales orders, purchase orders, projects
+CREATE TABLE IF NOT EXISTS sales_order_statuses (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  ordinal INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS purchase_order_statuses (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  ordinal INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS project_statuses (
+  code TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  ordinal INTEGER
+);
+
+-- Seed common codes (idempotent)
+INSERT INTO sales_order_statuses(code,name,ordinal) VALUES
+  ('draft','Draft',10),('confirmed','Confirmed',20),('fulfilled','Fulfilled',30),('cancelled','Cancelled',90)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO purchase_order_statuses(code,name,ordinal) VALUES
+  ('draft','Draft',10),('ordered','Ordered',20),('received','Received',30),('cancelled','Cancelled',90)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO project_statuses(code,name,ordinal) VALUES
+  ('planned','Planned',10),('active','Active',20),('onhold','On Hold',30),('closed','Closed',90)
+ON CONFLICT (code) DO NOTHING;

--- a/specs/db-status-fk-migration.md
+++ b/specs/db-status-fk-migration.md
@@ -6,6 +6,9 @@
 - tasks.status → task_statuses(code)
 - timesheets.approval_status → timesheet_statuses(code)
 - invoices.status → invoice_statuses(code)
+ - sales_orders.status → sales_order_statuses(code)（将来）
+ - purchase_orders.status → purchase_order_statuses(code)（将来）
+ - projects.status → project_statuses(code)（将来）
 
 ## 手順（例: invoices.status）
 1. 既存値の正規化（異表記を修正）
@@ -17,10 +20,11 @@
 5. CHECK制約を除去（移行完了後）
 6. アプリ側の列挙はLookup参照へ切替
 
+（Sales/Procurement/Projectも同様の手順で移行。まずLookup作成→seed→NOT VALID FK→VALIDATE→必要に応じてCHECK廃止）
+
 ## ロールバック
 - FKをDROPしてCHECKを一時復帰。データ不整合の修復後に再適用。
 
 ## 備考
 - 将来的に多言語名称はLookup側で管理
 - 監査はコード値の変更/追加を記録
-


### PR DESCRIPTION
目的: status-codes拡張に伴い、sales_order/purchase_order/project のlookupテーブルを追加し、移行計画を拡張します。