### PR TITLE
docs(openapi): allowed sort fields for compliance search

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -141,6 +141,7 @@ paths:
     get:
       tags: [compliance]
       summary: 電子取引保存の検索
+      description: ソート対象: `issue_date`, `amount`, `invoice_number`, `counterparty`（降順は `-field`）。
       security:
         - bearerAuth: []
       parameters:

--- a/specs/compliance.md
+++ b/specs/compliance.md
@@ -22,6 +22,7 @@
 - 一致種別: `match=exact|partial`
 - 結合: `operator=and|or`
 - 自由語: `q`（対象: `invoice_number`, `counterparty`）
+- ソート: `sort=issue_date|amount|invoice_number|counterparty`（降順は `-field`）
 
 ### レスポンス例（要約）
 ```json


### PR DESCRIPTION
目的: 電子取引検索のソート可能フィールドをOpenAPI/Docsに明示します。