### PR TITLE
docs+openapi: finalize remaining spec items

### DIFF
--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -437,6 +437,7 @@ components:
     SalesOrderLine:
       type: object
       properties:
+        line_id: { type: string, description: クライアント側の行識別子（任意） }
         item_code: { type: string }
         description: { type: string }
         qty: { type: number }
@@ -446,6 +447,7 @@ components:
     PurchaseOrderLine:
       type: object
       properties:
+        line_id: { type: string, description: クライアント側の行識別子（任意） }
         item_code: { type: string }
         description: { type: string }
         qty: { type: number }
@@ -544,8 +546,12 @@ components:
         counterparty: { type: string }
         amount: { type: number }
         tax_amount: { type: number }
-        file_uri: { type: string }
-        hash: { type: string }
+        file_uri:
+          type: string
+          x-sensitive: true
+        hash:
+          type: string
+          x-sensitive: true
         timestamp: { type: string, format: date-time }
         highlights:
           type: object

--- a/specs/api-errors.md
+++ b/specs/api-errors.md
@@ -1,0 +1,9 @@
+# APIエラー方針（ドラフト）
+
+- エラーモデル: `{ error: { code, message, details[] } }`
+- 主なHTTPコード
+  - 400 Bad Request: フォーマット不正
+  - 401/403: 認証/認可
+  - 409 Conflict: 重複作成・状態遷移の衝突（例: 連携APIの重複）
+  - 422 Unprocessable Entity: 検証エラー（例: 税率未設定、丸め設定不整合）
+- 冪等: `Idempotency-Key` ヘッダで同一リクエストの再実行を許容

--- a/specs/erd-attributes.md
+++ b/specs/erd-attributes.md
@@ -1,0 +1,14 @@
+# ERD属性詳細（MVP）
+
+各テーブルの主属性・必須・型のサマリ（抜粋）。完全版はDDL参照。
+
+- projects(id text pk, tenant_id text not null, code text not null unique(tenant,code), name text not null, client_id text, status text not null, start_on date, end_on date, created_at ts not null, ...)
+- tasks(id text pk, tenant_id text not null, project_id text not null, name text not null, status text not null check in, created_at ts not null, ...)
+- timesheets(id text pk, tenant_id text not null, user_id text not null, project_id text not null, task_id text null, work_date date not null, hours numeric(6,2) >=0, approval_status text not null check in, created_at ts not null, ...)
+- invoices(id text pk, tenant_id text not null, account_id text not null, issue_date date not null, due_date date, status text not null check in, invoice_number text not null unique(tenant,number), total numeric(18,2) >=0, tax_total numeric(18,2) >=0, created_at ts not null, ...)
+- invoice_lines(id text pk, invoice_id text not null, item_code text, description text, qty numeric(12,2) not null default 1, unit_price numeric(18,2) not null default 0, tax_rate numeric(5,2) 0..100, tax_code text, created_at ts not null, ...)
+- payments(id text pk, tenant_id text not null, invoice_id text not null, amount numeric(18,2) >=0, paid_on date not null, method text, created_at ts not null, ...)
+- cost_snapshots(id text pk, tenant_id text not null, project_id text not null, as_of_date date not null, revenue_progress numeric(5,4) 0..1, gross_profit numeric(18,2), created_at ts not null, ...)
+- audit_logs(id text pk, tenant_id text not null, occurred_at ts not null default now, actor_user_id text, action text not null, entity_type text, entity_id text, before_data jsonb, after_data jsonb, ip text, user_agent text)
+
+索引・一意・ON DELETEなどの方針は db-policy.md を参照。

--- a/specs/status-codes.md
+++ b/specs/status-codes.md
@@ -6,4 +6,8 @@
 - データ源: DBのlookupテーブル（task_statuses / timesheet_statuses / invoice_statuses）
 - キャッシュ: 数分〜数時間のキャッシュ可（頻繁に変化しない）
 
+パラメータ:
+- `active=true|false`（true指定で有効のみ）
+- `sort=ordinal|code|name`（降順は `-field`）
+
 今後: ドメイン拡張や無効化フラグ、並び順などを追加検討（active/ordinalは任意）。

--- a/specs/update-semantics.md
+++ b/specs/update-semantics.md
@@ -1,0 +1,15 @@
+# 更新セマンティクス（PATCH）
+
+対象: SalesOrder / PurchaseOrder の PATCH 更新。
+
+## lines_mode
+- `replace`（既定）: 送信された `lines` で完全置換（未指定の既存行は削除）
+- `merge`: `line_id` または `item_code` をキーに既存行を上書き/追加。未指定行は残す。
+
+## 行識別
+- `line_id`（推奨）: クライアント側生成の行ID。なければ `item_code` を暫定キーに利用。
+- 削除は `replace` を用いるか、将来 `op: remove` の導入を検討。
+
+## 丸め・金額
+- 行の `amount` はサーバ側で `qty × unit_price` を元に再計算（不一致は優先度: サーバ）
+- 丸めはテナント/契約設定に従う（links.md 参照）。


### PR DESCRIPTION
目的: 提案残タスクの仕様補完（status-codes filters/ソート、PATCHセマンティクス、エラーポリシー、x-sensitive、ERD属性、連携の冪等+エラー）を反映します。