### PR TITLE
feat: align AE modules with stateful APIs

### DIFF
--- a/ae/modules/contracts/mapping.yaml
+++ b/ae/modules/contracts/mapping.yaml
@@ -1,0 +1,11 @@
+entities:
+  Contract:
+    table: contracts
+    pk: id
+    fields:
+      account_id: account_id
+      type: type
+      start_on: start_on
+      end_on: end_on
+      billing_terms: billing_terms
+      progress_method: progress_method

--- a/ae/modules/contracts/module.yaml
+++ b/ae/modules/contracts/module.yaml
@@ -1,5 +1,6 @@
 name: contracts
 includeTags: [contracts]
+owned_tables: [contracts]
 paths:
   list: /api/v1/contracts
   create: /api/v1/contracts

--- a/ae/modules/procurement/mapping.yaml
+++ b/ae/modules/procurement/mapping.yaml
@@ -1,5 +1,13 @@
 planned: true
 entities:
+  Vendor:
+    table: vendors
+    pk: id
+    fields:
+      code: code
+      name: name
+      status: status
+      account_id: account_id
   PurchaseOrder:
     table: purchase_orders
     pk: id
@@ -7,13 +15,48 @@ entities:
       vendor_id: vendor_id
       order_date: order_date
       status: status
+      expected_date: expected_date
+      total: total
+      tax_total: tax_total
+      currency: currency
+      notes: notes
   PurchaseOrderLine:
     table: purchase_order_lines
     pk: id
     fields:
       purchase_order_id: purchase_order_id
-      line_id: client_line_id
+      line_no: line_no
+      client_line_id: client_line_id
       item_code: item_code
       description: description
       qty: qty
       unit_price: unit_price
+      amount: amount
+      tax_rate: tax_rate
+  VendorBill:
+    table: vendor_bills
+    pk: id
+    fields:
+      vendor_id: vendor_id
+      purchase_order_id: purchase_order_id
+      bill_number: bill_number
+      status: status
+      bill_date: bill_date
+      due_date: due_date
+      total: total
+      tax_total: tax_total
+      currency: currency
+      notes: notes
+  VendorBillLine:
+    table: vendor_bill_lines
+    pk: id
+    fields:
+      vendor_bill_id: vendor_bill_id
+      line_no: line_no
+      client_line_id: client_line_id
+      item_code: item_code
+      description: description
+      qty: qty
+      unit_price: unit_price
+      amount: amount
+      tax_rate: tax_rate

--- a/ae/modules/procurement/module.yaml
+++ b/ae/modules/procurement/module.yaml
@@ -1,5 +1,6 @@
 name: procurement
 includeTags: [procurement]
+owned_tables: [vendors, purchase_orders, purchase_order_lines, vendor_bills, vendor_bill_lines]
 paths:
   list: /api/v1/procurement/purchase-orders
   create: /api/v1/procurement/purchase-orders

--- a/ae/modules/projects/module.yaml
+++ b/ae/modules/projects/module.yaml
@@ -6,7 +6,24 @@ paths:
 generate:
   list: true
   get: true
+actions:
+  - name: activate
+    method: POST
+    path: /api/v1/projects/{id}/activate
+  - name: hold
+    method: POST
+    path: /api/v1/projects/{id}/hold
+  - name: resume
+    method: POST
+    path: /api/v1/projects/{id}/resume
+  - name: close
+    method: POST
+    path: /api/v1/projects/{id}/close
 relations:
   - from: projects.client_id
     to: accounts.id
     type: many-to-one
+states:
+  file: states.yaml
+permissions:
+  scope: projects

--- a/ae/modules/projects/states.yaml
+++ b/ae/modules/projects/states.yaml
@@ -1,0 +1,16 @@
+entity: project
+initial: planned
+states: [planned, active, onhold, closed]
+transitions:
+  - from: planned
+    to: active
+    action: activate
+  - from: [planned, active]
+    to: onhold
+    action: hold
+  - from: onhold
+    to: active
+    action: resume
+  - from: [planned, active, onhold]
+    to: closed
+    action: close

--- a/ae/modules/sales/mapping.yaml
+++ b/ae/modules/sales/mapping.yaml
@@ -7,13 +7,20 @@ entities:
       account_id: account_id
       order_date: order_date
       status: status
+      total: total
+      tax_total: tax_total
+      currency: currency
+      notes: notes
   SalesOrderLine:
     table: sales_order_lines
     pk: id
     fields:
       sales_order_id: sales_order_id
-      line_id: client_line_id
+      line_no: line_no
+      client_line_id: client_line_id
       item_code: item_code
       description: description
       qty: qty
       unit_price: unit_price
+      amount: amount
+      tax_rate: tax_rate

--- a/ae/modules/sales/module.yaml
+++ b/ae/modules/sales/module.yaml
@@ -1,6 +1,6 @@
 name: sales
 includeTags: [sales]
-owned_tables: [] # 注: テーブルは別モジュールで管理する場合あり
+owned_tables: [sales_orders, sales_order_lines]
 paths:
   list: /api/v1/sales/orders
   create: /api/v1/sales/orders

--- a/ae/modules/timesheets/module.yaml
+++ b/ae/modules/timesheets/module.yaml
@@ -4,8 +4,23 @@ owned_tables: [timesheets]
 paths:
   list: /api/v1/timesheets
   create: /api/v1/timesheets
+actions:
+  - name: submit
+    method: POST
+    path: /api/v1/timesheets/{id}/submit
+  - name: approve
+    method: POST
+    path: /api/v1/timesheets/{id}/approve
+  - name: reject
+    method: POST
+    path: /api/v1/timesheets/{id}/reject
+  - name: resubmit
+    method: POST
+    path: /api/v1/timesheets/{id}/resubmit
 dto:
   create:
     required: [user_id, project_id, work_date, hours]
+states:
+  file: states.yaml
 permissions:
   scope: timesheets

--- a/ae/modules/timesheets/states.yaml
+++ b/ae/modules/timesheets/states.yaml
@@ -1,0 +1,16 @@
+entity: timesheet
+initial: draft
+states: [draft, submitted, approved, rejected]
+transitions:
+  - from: draft
+    to: submitted
+    action: submit
+  - from: submitted
+    to: approved
+    action: approve
+  - from: submitted
+    to: rejected
+    action: reject
+  - from: rejected
+    to: submitted
+    action: resubmit

--- a/ae/permissions.yaml
+++ b/ae/permissions.yaml
@@ -9,9 +9,16 @@ roles:
     - 'invoices.read'
   project_manager:
     - 'projects.*'
-    - 'timesheets.read'
+    - 'timesheets.list'
+    - 'timesheets.get'
+    - 'timesheets.approve'
+    - 'timesheets.reject'
   user:
-    - 'timesheets.*'
+    - 'timesheets.list'
+    - 'timesheets.get'
+    - 'timesheets.create'
+    - 'timesheets.submit'
+    - 'timesheets.resubmit'
 
 scopes:
   projects:
@@ -19,10 +26,18 @@ scopes:
     - get
     - create
     - update
+    - activate
+    - hold
+    - resume
+    - close
   timesheets:
     - list
     - create
     - get
+    - submit
+    - approve
+    - reject
+    - resubmit
   sales:
     - list
     - get
@@ -41,6 +56,13 @@ scopes:
     - receive
     - cancel
     - bill
+  contracts:
+    - list
+    - create
+    - get
+    - update
+    - renewalAlert
+    - esign
   compliance:
     - save
     - search

--- a/openapi/v1/openapi.yaml
+++ b/openapi/v1/openapi.yaml
@@ -53,6 +53,94 @@ paths:
         default:
           $ref: '#/components/responses/Error'
 
+  /api/v1/projects/{id}/activate:
+    post:
+      tags: [projects]
+      summary: プロジェクト開始
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: OK }
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/projects/{id}/hold:
+    post:
+      tags: [projects]
+      summary: プロジェクト一時停止
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: { type: string }
+      responses:
+        '200': { description: OK }
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/projects/{id}/resume:
+    post:
+      tags: [projects]
+      summary: プロジェクト再開
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: OK }
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/projects/{id}/close:
+    post:
+      tags: [projects]
+      summary: プロジェクト完了
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                closed_on:
+                  type: string
+                  format: date
+                comment:
+                  type: string
+      responses:
+        '200': { description: OK }
+        default:
+          $ref: '#/components/responses/Error'
+
   /api/v1/timesheets:
     get:
       tags: [timesheets]
@@ -93,6 +181,110 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TimesheetEntry'
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/timesheets/{id}/submit:
+    post:
+      tags: [timesheets]
+      summary: タイムシート提出
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimesheetStateChangeRequest'
+      responses:
+        '202':
+          description: Accepted
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/timesheets/{id}/approve:
+    post:
+      tags: [timesheets]
+      summary: タイムシート承認
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimesheetStateChangeRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TimesheetEntry'
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/timesheets/{id}/reject:
+    post:
+      tags: [timesheets]
+      summary: タイムシート差戻し
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimesheetStateChangeRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TimesheetEntry'
+        default:
+          $ref: '#/components/responses/Error'
+
+  /api/v1/timesheets/{id}/resubmit:
+    post:
+      tags: [timesheets]
+      summary: タイムシート再提出
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TenantHeader'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimesheetStateChangeRequest'
+      responses:
+        '202':
+          description: Accepted
         default:
           $ref: '#/components/responses/Error'
 
@@ -384,6 +576,16 @@ components:
           type: string
           enum: [draft, submitted, approved, rejected]
       required: [user_id, project_id, work_date, hours]
+    TimesheetStateChangeRequest:
+      type: object
+      properties:
+        comment:
+          type: string
+          description: 承認・差戻し時の備考
+        reason_code:
+          type: string
+          description: 差戻し理由コード（オプション）
+      additionalProperties: false
     PaginatedTimesheets:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- add project and timesheet state machines and extend AE module definitions
- wire permissions and mappings to new sales/procurement data structures
- expose timesheet/project actions in OpenAPI for generator alignment

## Testing
- not applicable

Refs #75