### PR TITLE
feat(ui-poc): add projects portfolio screen

### DIFF
--- a/ui-poc/.env.local.example
+++ b/ui-poc/.env.local.example
@@ -3,3 +3,6 @@ NEXT_PUBLIC_API_BASE=http://localhost:3001
 
 # Optional: enable request logging in the browser console
 NEXT_PUBLIC_ENABLE_API_LOGGING=true
+
+# Optional: base URL for server components fetching mock data
+POC_API_BASE=http://localhost:3001

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -26,7 +26,7 @@ cp .env.local.example .env.local  # 必要に応じて API エンドポイント
 ## ディレクトリ構成（抜粋）
 
 - `src/app` … App Router を用いた画面コンポーネント
-  - `/projects` … プロジェクトポートフォリオ PoC
+  - `/projects` … プロジェクトポートフォリオ PoC（Podman 起動時は `/api/v1/projects` をフェッチ）
   - `/timesheets` … タイムシート承認 PoC
   - `/compliance` … 電子取引検索 PoC
 - `src/lib/api-client.ts` … API呼び出し用の簡易ラッパ

--- a/ui-poc/src/app/projects/page.tsx
+++ b/ui-poc/src/app/projects/page.tsx
@@ -1,34 +1,36 @@
-import Link from "next/link";
+import { ProjectsClient } from "@/features/projects/ProjectsClient";
+import { mockProjects } from "@/features/projects/mock-data";
+import type { ProjectListResponse } from "@/features/projects/types";
 
-export default function ProjectsPage() {
+async function fetchProjects(): Promise<ProjectListResponse> {
+  const base = process.env.POC_API_BASE ?? "http://localhost:3001";
+  try {
+    const res = await fetch(`${base}/api/v1/projects`, { cache: "no-store" });
+    if (!res.ok) {
+      throw new Error(`status ${res.status}`);
+    }
+    return (await res.json()) as ProjectListResponse;
+  } catch (error) {
+    console.warn("[projects] falling back to mock data due to fetch error", error);
+    return mockProjects;
+  }
+}
+
+export default async function ProjectsPage() {
+  const data = await fetchProjects();
+
   return (
     <section className="space-y-6">
       <header className="space-y-2">
         <h2 className="text-2xl font-semibold text-white">Projects PoC</h2>
         <p className="text-sm text-slate-400">
-          プロジェクト一覧のUX検討ページです。現時点ではモックデータを表示しつつ、状態遷移や
-          外部イベントとの連携パターンを設計するための土台を提供します。
+          プロジェクトポートフォリオのUXを検討するための画面です。現時点ではモックデータを表示し、
+          状態遷移の操作感やカードレイアウトの方向性を確認できます。Podman バックエンドを起動した
+          状態では <code>/api/v1/projects</code> を通じて PoC データが表示されます。
         </p>
       </header>
 
-      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-sm text-slate-300">
-        <p>
-          この画面には、以下の要素を順次追加していきます:
-        </p>
-        <ul className="mt-2 space-y-1 list-disc list-inside text-slate-400">
-          <li>プロジェクトカードの一覧/検索/フィルタ</li>
-          <li>状態遷移アクション（Activate / Hold / Resume / Close）</li>
-          <li>Sales イベント連携による自動プロジェクト生成の可視化</li>
-        </ul>
-      </div>
-
-      <p className="text-sm text-slate-500">
-        Timesheets や Compliance 画面も合わせて確認すると、案件→工数→請求までの業務体験を俯瞰できます。
-        <Link href="/timesheets" className="text-sky-400 hover:underline">
-          次は Timesheets へ
-        </Link>
-        。
-      </p>
+      <ProjectsClient initialProjects={data} />
     </section>
   );
 }

--- a/ui-poc/src/features/projects/ProjectsClient.tsx
+++ b/ui-poc/src/features/projects/ProjectsClient.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useMemo, useState } from "react";
+import { apiRequest } from "@/lib/api-client";
+import { STATUS_LABEL, type ProjectAction, type ProjectListResponse, type ProjectStatus } from "./types";
+
+const statusFilters: Array<{ value: "all" | ProjectStatus; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "planned", label: STATUS_LABEL.planned },
+  { value: "active", label: STATUS_LABEL.active },
+  { value: "onhold", label: STATUS_LABEL.onhold },
+  { value: "closed", label: STATUS_LABEL.closed },
+];
+
+const transitions: Record<ProjectStatus, ProjectAction[]> = {
+  planned: ["activate", "close"],
+  active: ["hold", "close"],
+  onhold: ["resume", "close"],
+  closed: [],
+};
+
+const actionLabel: Record<ProjectAction, string> = {
+  activate: "Activate",
+  hold: "Hold",
+  resume: "Resume",
+  close: "Close",
+};
+
+const HEALTH_CLASS: Record<string, string> = {
+  green: "bg-emerald-500",
+  yellow: "bg-amber-400",
+  red: "bg-rose-500",
+};
+
+type ProjectsClientProps = {
+  initialProjects: ProjectListResponse;
+};
+
+type ProjectItem = ProjectListResponse["items"][number];
+
+type UpdateState = {
+  id: string | null;
+  message: string | null;
+  variant: "success" | "error" | null;
+};
+
+export function ProjectsClient({ initialProjects }: ProjectsClientProps) {
+  const [projects, setProjects] = useState(initialProjects.items);
+  const [filter, setFilter] = useState<(typeof statusFilters)[number]["value"]>("all");
+  const [updateState, setUpdateState] = useState<UpdateState>({ id: null, message: null, variant: null });
+  const [pending, setPending] = useState<string | null>(null);
+
+  const filteredProjects = useMemo(() => {
+    if (filter === "all") return projects;
+    return projects.filter((p) => p.status === filter);
+  }, [projects, filter]);
+
+  const handleAction = async (project: ProjectItem, action: ProjectAction) => {
+    setPending(project.id);
+    setUpdateState({ id: project.id, message: null, variant: null });
+    try {
+      await apiRequest<unknown>({
+        path: `/api/v1/projects/${project.id}/${action}`,
+        method: "POST",
+      });
+      const nextStatus = inferNextStatus(project.status, action);
+      setProjects((prev) =>
+        prev.map((item) =>
+          item.id === project.id
+            ? {
+                ...item,
+                status: nextStatus,
+              }
+            : item,
+        ),
+      );
+      setUpdateState({ id: project.id, message: `${actionLabel[action]} succeeded`, variant: "success" });
+    } catch (error) {
+      console.error("project action failed", error);
+      setUpdateState({ id: project.id, message: `Failed to ${actionLabel[action].toLowerCase()}`, variant: "error" });
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-2">
+        {statusFilters.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() => setFilter(item.value)}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              filter === item.value ? "border-sky-400 bg-sky-500/20 text-sky-100" : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600 hover:text-slate-200"
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {filteredProjects.map((project) => (
+          <article key={project.id} className="rounded-xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/50">
+            <header className="flex items-start justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2 text-xs text-slate-400">
+                  <span>{project.code}</span>
+                  {project.clientName ? <span>• {project.clientName}</span> : null}
+                </div>
+                <h3 className="mt-1 text-lg font-semibold text-white">{project.name}</h3>
+              </div>
+              <StatusBadge status={project.status} />
+            </header>
+
+            <dl className="mt-4 grid grid-cols-2 gap-2 text-xs text-slate-400">
+              <div>
+                <dt className="uppercase tracking-wide">Start</dt>
+                <dd className="text-slate-200">{project.startOn ?? "—"}</dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide">End</dt>
+                <dd className="text-slate-200">{project.endOn ?? "—"}</dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide">Manager</dt>
+                <dd className="text-slate-200">{project.manager ?? "未設定"}</dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide">Health</dt>
+                <dd className="flex items-center gap-2 text-slate-200">
+                  <span className={`h-2 w-2 rounded-full ${HEALTH_CLASS[project.health ?? "green"] ?? HEALTH_CLASS.green}`} />
+                  {project.health ?? "—"}
+                </dd>
+              </div>
+            </dl>
+
+            {project.tags && project.tags.length > 0 ? (
+              <div className="mt-4 flex flex-wrap gap-1 text-[11px] text-slate-300">
+                {project.tags.map((tag) => (
+                  <span key={tag} className="rounded-full border border-slate-700 px-2 py-0.5">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="mt-6 flex flex-wrap gap-2">
+              {transitions[project.status].length === 0 ? (
+                <span className="text-xs text-slate-500">No further actions</span>
+              ) : (
+                transitions[project.status].map((action) => (
+                  <button
+                    key={action}
+                    type="button"
+                    disabled={pending === project.id}
+                    onClick={() => handleAction(project, action)}
+                    className={`rounded-md border px-3 py-1 text-xs font-medium transition-colors ${
+                      pending === project.id
+                        ? "cursor-not-allowed border-slate-700 bg-slate-800 text-slate-500"
+                        : "border-slate-700 bg-slate-800 text-slate-200 hover:border-slate-600 hover:text-white"
+                    }`}
+                  >
+                    {actionLabel[action]}
+                  </button>
+                ))
+              )}
+            </div>
+
+            {updateState.id === project.id && updateState.variant ? (
+              <p
+                className={`mt-3 text-xs ${
+                  updateState.variant === "success" ? "text-emerald-400" : "text-rose-400"
+                }`}
+              >
+                {updateState.message}
+              </p>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function inferNextStatus(current: ProjectStatus, action: ProjectAction): ProjectStatus {
+  switch (action) {
+    case "activate":
+      return "active";
+    case "hold":
+      return "onhold";
+    case "resume":
+      return "active";
+    case "close":
+      return "closed";
+    default:
+      return current;
+  }
+}
+
+function StatusBadge({ status }: { status: ProjectStatus }) {
+  const color =
+    status === "active"
+      ? "bg-emerald-500/20 text-emerald-300 border-emerald-500/40"
+      : status === "planned"
+        ? "bg-slate-600/20 text-slate-200 border-slate-500/50"
+        : status === "onhold"
+          ? "bg-amber-400/20 text-amber-200 border-amber-400/40"
+          : "bg-rose-500/20 text-rose-200 border-rose-500/40";
+
+  return (
+    <span className={`rounded-full border px-3 py-1 text-xs font-medium ${color}`}>
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/ui-poc/src/features/projects/mock-data.ts
+++ b/ui-poc/src/features/projects/mock-data.ts
@@ -1,0 +1,48 @@
+import type { ProjectListResponse } from "./types";
+
+export const mockProjects: ProjectListResponse = {
+  items: [
+    {
+      id: "PRJ-1001",
+      code: "DX-2025-01",
+      name: "DX推進プロジェクト",
+      clientName: "Acme Corp",
+      status: "active",
+      startOn: "2025-04-01",
+      manager: "山田太郎",
+      health: "green",
+      tags: ["DX", "Priority"],
+    },
+    {
+      id: "PRJ-1002",
+      code: "OPS-BCP",
+      name: "BCP整備プログラム",
+      clientName: "Internal",
+      status: "onhold",
+      startOn: "2025-05-10",
+      health: "yellow",
+      tags: ["Risk", "Compliance"],
+    },
+    {
+      id: "PRJ-1003",
+      code: "SAP-ROLL",
+      name: "SAPロールアウトフェーズ2",
+      clientName: "Itdo Manufacturing",
+      status: "planned",
+      startOn: "2025-11-01",
+      health: "green",
+      tags: ["SAP", "Rollout"],
+    },
+    {
+      id: "PRJ-1004",
+      code: "AMS-2024",
+      name: "アプリ保守2024",
+      clientName: "Acme Corp",
+      status: "closed",
+      startOn: "2024-01-01",
+      endOn: "2024-12-31",
+      health: "green",
+      tags: ["AMS"],
+    },
+  ],
+};

--- a/ui-poc/src/features/projects/types.ts
+++ b/ui-poc/src/features/projects/types.ts
@@ -1,0 +1,28 @@
+export type ProjectStatus = "planned" | "active" | "onhold" | "closed";
+
+export type ProjectSummary = {
+  id: string;
+  code: string;
+  name: string;
+  clientName?: string;
+  status: ProjectStatus;
+  startOn?: string;
+  endOn?: string;
+  health?: "green" | "yellow" | "red";
+  manager?: string;
+  tags?: string[];
+};
+
+export type ProjectListResponse = {
+  items: ProjectSummary[];
+  next_cursor?: string;
+};
+
+export type ProjectAction = "activate" | "hold" | "resume" | "close";
+
+export const STATUS_LABEL: Record<ProjectStatus, string> = {
+  planned: "Planned",
+  active: "Active",
+  onhold: "On Hold",
+  closed: "Closed",
+};


### PR DESCRIPTION
## Summary
- add a Projects PoC screen with status filters, mock data display and action buttons
- implement client-side project action handling backed by the existing API helper
- fall back to mock data when Podman API is unreachable and document the new env var

## Testing
- npm run lint (ui-poc)
