### PR TITLE
feat(ui-poc): 電子取引検索PoCの実装

### DIFF
--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -28,7 +28,7 @@ cp .env.local.example .env.local  # 必要に応じて API エンドポイント
 - `src/app` … App Router を用いた画面コンポーネント
   - `/projects` … プロジェクトポートフォリオ PoC（Podman 起動時は `/api/v1/projects` をフェッチ）
   - `/timesheets` … タイムシート承認 PoC（Podman 起動時は `/api/v1/timesheets` をフェッチ）
-  - `/compliance` … 電子取引検索 PoC
+  - `/compliance` … 電子取引検索 PoC（Podman 起動時は `/api/v1/compliance/invoices` をフェッチ）
 - `src/features` … 画面単位のモジュール（型定義・モックデータ・UIロジック）
 - `src/lib/api-client.ts` … API呼び出し用の簡易ラッパ
 

--- a/ui-poc/src/app/compliance/page.tsx
+++ b/ui-poc/src/app/compliance/page.tsx
@@ -1,29 +1,43 @@
-export default function CompliancePage() {
+import { ComplianceClient } from "@/features/compliance/ComplianceClient";
+import { mockInvoices } from "@/features/compliance/mock-data";
+import type { InvoiceListResponse } from "@/features/compliance/types";
+
+async function fetchComplianceInvoices(): Promise<InvoiceListResponse> {
+  const base = process.env.POC_API_BASE ?? "http://localhost:3001";
+  try {
+    const res = await fetch(`${base}/api/v1/compliance/invoices?limit=25`, { cache: "no-store" });
+    if (!res.ok) {
+      throw new Error(`status ${res.status}`);
+    }
+    const data = (await res.json()) as Partial<InvoiceListResponse>;
+    return {
+      items: data.items ?? [],
+      meta: {
+        total: data.meta?.total ?? data.items?.length ?? 0,
+        fetchedAt: data.meta?.fetchedAt ?? new Date().toISOString(),
+        fallback: data.meta?.fallback ?? false,
+      },
+    } satisfies InvoiceListResponse;
+  } catch (error) {
+    console.warn("[compliance] falling back to mock data due to fetch error", error);
+    return mockInvoices;
+  }
+}
+
+export default async function CompliancePage() {
+  const data = await fetchComplianceInvoices();
+
   return (
     <section className="space-y-6">
       <header className="space-y-2">
         <h2 className="text-2xl font-semibold text-white">Compliance PoC</h2>
         <p className="text-sm text-slate-400">
-          電子取引（インボイス）検索と添付確認の体験を検証するページです。複合フィルタ、結果一覧、
-          添付プレビューなどのUIパターンを段階的に実装していきます。
+          電子取引（インボイス）検索のUXを検証する画面です。複合フィルタで請求書を絞り込み、
+          添付ファイルの確認や照合作業メモを想定した操作パターンを確認できます。
         </p>
       </header>
 
-      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-sm text-slate-300">
-        <p>検討中の要素：</p>
-        <ul className="mt-2 space-y-1 list-disc list-inside text-slate-400">
-          <li>期間・金額・フリーワード・match/operator 等の複合検索フォーム</li>
-          <li>検索条件の保存/共有機能、リザルトテーブルの列構成</li>
-          <li>添付ファイルのプレビュー / ダウンロード / 監査ログ参照</li>
-        </ul>
-      </div>
-
-      <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-xs text-slate-400">
-        <p>
-          バックエンドとの疎通を確認する際は Podman スタックの `compliance/invoices` エンドポイント
-          を利用します。PoC段階ではサンプルレスポンスを利用したモック表示から開始する予定です。
-        </p>
-      </div>
+      <ComplianceClient initialData={data} />
     </section>
   );
 }

--- a/ui-poc/src/features/compliance/ComplianceClient.tsx
+++ b/ui-poc/src/features/compliance/ComplianceClient.tsx
@@ -23,6 +23,8 @@ const initialFormState: InvoiceSearchFormState = {
 
 type QuerySource = "api" | "mock";
 
+const TABLE_COLUMN_COUNT = 7;
+
 type ComplianceClientProps = {
   initialData: InvoiceListResponse;
 };
@@ -214,7 +216,7 @@ export function ComplianceClient({ initialData }: ComplianceClientProps) {
           <tbody className="divide-y divide-slate-800">
             {invoices.length === 0 ? (
               <tr>
-                <td className="px-4 py-6 text-center text-slate-400" colSpan={7}>
+                <td className="px-4 py-6 text-center text-slate-400" colSpan={TABLE_COLUMN_COUNT}>
                   条件に一致する請求書が見つかりませんでした。
                 </td>
               </tr>
@@ -436,7 +438,7 @@ function formatCurrency(value: number, currency: string): string {
 
 function formatDate(date: string): string {
   if (!date) return "—";
-  const parsed = new Date(`${date}T00:00:00`);
+  const parsed = parseIsoDate(date);
   if (Number.isNaN(parsed.getTime())) {
     return date;
   }
@@ -481,4 +483,8 @@ function badgeColor(status: InvoiceRecord["status"]): string {
     default:
       return "bg-slate-500/20 text-slate-200";
   }
+}
+
+function parseIsoDate(date: string): Date {
+  return new Date(`${date}T00:00:00Z`);
 }

--- a/ui-poc/src/features/compliance/ComplianceClient.tsx
+++ b/ui-poc/src/features/compliance/ComplianceClient.tsx
@@ -1,0 +1,484 @@
+'use client';
+
+import { useMemo, useState } from "react";
+import type { ChangeEventHandler, FormEventHandler } from "react";
+import { apiRequest } from "@/lib/api-client";
+import { searchMockInvoices, statusOptions } from "./mock-data";
+import type {
+  InvoiceAttachment,
+  InvoiceListResponse,
+  InvoiceRecord,
+  InvoiceSearchFormState,
+} from "./types";
+import { STATUS_LABEL } from "./types";
+
+const initialFormState: InvoiceSearchFormState = {
+  keyword: "",
+  status: "all",
+  startDate: "",
+  endDate: "",
+  minAmount: "",
+  maxAmount: "",
+};
+
+type QuerySource = "api" | "mock";
+
+type ComplianceClientProps = {
+  initialData: InvoiceListResponse;
+};
+
+export function ComplianceClient({ initialData }: ComplianceClientProps) {
+  const [form, setForm] = useState<InvoiceSearchFormState>(initialFormState);
+  const [invoices, setInvoices] = useState(initialData.items);
+  const [meta, setMeta] = useState(initialData.meta);
+  const [source, setSource] = useState<QuerySource>(initialData.meta.fallback ? "mock" : "api");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(initialData.items[0]?.id ?? null);
+  const [previewAttachment, setPreviewAttachment] = useState<InvoiceAttachment | null>(null);
+
+  const selectedInvoice = useMemo(() => {
+    if (!selectedId) return null;
+    return invoices.find((invoice) => invoice.id === selectedId) ?? null;
+  }, [invoices, selectedId]);
+
+  const handleChange = (
+    field: keyof InvoiceSearchFormState,
+  ): ChangeEventHandler<HTMLInputElement | HTMLSelectElement> => {
+    return (event) => {
+      setForm((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+  };
+
+  const handleSearch: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const query = buildQueryString(form);
+    const path = query ? `/api/v1/compliance/invoices?${query}` : "/api/v1/compliance/invoices";
+
+    try {
+      const response = await apiRequest<InvoiceListResponse>({ path });
+      setInvoices(response.items);
+      setMeta(response.meta);
+      setSource(response.meta.fallback ? "mock" : "api");
+      setSelectedId(response.items[0]?.id ?? null);
+    } catch (err) {
+      console.warn("[compliance] falling back to mock data", err);
+      const fallbackItems = searchMockInvoices(form);
+      setInvoices(fallbackItems);
+      setMeta({
+        total: fallbackItems.length,
+        fetchedAt: new Date().toISOString(),
+        fallback: true,
+      });
+      setSource("mock");
+      setSelectedId(fallbackItems[0]?.id ?? null);
+      setError("APIの取得に失敗したため、モックデータを表示しています。");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReset = () => {
+    setForm(initialFormState);
+    setInvoices(initialData.items);
+    setMeta(initialData.meta);
+    setSource(initialData.meta.fallback ? "mock" : "api");
+    setSelectedId(initialData.items[0]?.id ?? null);
+    setError(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <form
+        className="grid gap-4 rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-sm text-slate-200 md:grid-cols-4"
+        onSubmit={handleSearch}
+      >
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">フリーワード</span>
+          <input
+            value={form.keyword}
+            onChange={handleChange("keyword")}
+            placeholder="請求書番号 / 取引先 / タグ等"
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">請求書ステータス</span>
+          <select
+            value={form.status}
+            onChange={handleChange("status")}
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none"
+          >
+            {statusOptions().map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">発行日 (From)</span>
+          <input
+            type="date"
+            value={form.startDate}
+            onChange={handleChange("startDate")}
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">発行日 (To)</span>
+          <input
+            type="date"
+            value={form.endDate}
+            onChange={handleChange("endDate")}
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">金額 (Min)</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            value={form.minAmount}
+            onChange={handleChange("minAmount")}
+            placeholder="100000"
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none"
+          />
+        </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs uppercase tracking-wide text-slate-400">金額 (Max)</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            value={form.maxAmount}
+            onChange={handleChange("maxAmount")}
+            placeholder="500000"
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-400 focus:outline-none"
+          />
+        </label>
+
+        <div className="flex items-end gap-3 md:col-span-2">
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-md border border-sky-500 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-100 transition-colors hover:border-sky-400 hover:bg-sky-500/30 disabled:cursor-not-allowed disabled:border-slate-700 disabled:bg-slate-800 disabled:text-slate-500"
+          >
+            {loading ? "検索中..." : "検索"}
+          </button>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="rounded-md border border-slate-700 bg-slate-900 px-4 py-2 text-sm text-slate-300 transition-colors hover:border-slate-500 hover:text-white"
+          >
+            条件クリア
+          </button>
+        </div>
+      </form>
+
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+        <span>ヒット件数: {meta.total.toLocaleString()} 件</span>
+        <span>取得時刻: {formatDateTime(meta.fetchedAt)}</span>
+        <span
+          className={`rounded-full px-2 py-1 font-medium ${
+            source === "api"
+              ? "bg-emerald-500/20 text-emerald-200"
+              : "bg-amber-500/20 text-amber-200"
+          }`}
+        >
+          {source === "api" ? "API live" : "Mock data"}
+        </span>
+        {error ? <span className="text-amber-300">{error}</span> : null}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/50">
+        <table className="min-w-full divide-y divide-slate-800 text-sm">
+          <thead className="bg-slate-900/70 text-slate-300">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium">発行日</th>
+              <th className="px-4 py-3 text-left font-medium">請求書番号</th>
+              <th className="px-4 py-3 text-left font-medium">取引先</th>
+              <th className="px-4 py-3 text-left font-medium">件名</th>
+              <th className="px-4 py-3 text-right font-medium">税込金額</th>
+              <th className="px-4 py-3 text-left font-medium">ステータス</th>
+              <th className="px-4 py-3 text-left font-medium">タグ</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {invoices.length === 0 ? (
+              <tr>
+                <td className="px-4 py-6 text-center text-slate-400" colSpan={7}>
+                  条件に一致する請求書が見つかりませんでした。
+                </td>
+              </tr>
+            ) : (
+              invoices.map((invoice) => (
+                <tr
+                  key={invoice.id}
+                  onClick={() => setSelectedId(invoice.id)}
+                  className={`cursor-pointer transition-colors hover:bg-slate-800/40 ${
+                    selectedId === invoice.id ? "bg-slate-800/40" : ""
+                  }`}
+                >
+                  <td className="px-4 py-3 text-slate-200">{formatDate(invoice.issueDate)}</td>
+                  <td className="px-4 py-3 text-slate-200">
+                    <div className="flex flex-col">
+                      <span>{invoice.invoiceNumber}</span>
+                      <span className="text-xs text-slate-500">#{invoice.id}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-slate-200">
+                    <div className="flex flex-col">
+                      <span>{invoice.counterpartyName}</span>
+                      {invoice.counterpartyNumber ? (
+                        <span className="text-xs text-slate-500">{invoice.counterpartyNumber}</span>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-slate-200">{invoice.subject}</td>
+                  <td className="px-4 py-3 text-right text-slate-200">
+                    {formatCurrency(invoice.amountIncludingTax, invoice.currency)}
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    <StatusBadge status={invoice.status} />
+                  </td>
+                  <td className="px-4 py-3 text-xs text-slate-300">
+                    <div className="flex flex-wrap gap-1">
+                      {invoice.tags.map((tag) => (
+                        <span key={tag} className="rounded-md bg-slate-800 px-2 py-1">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {selectedInvoice ? <DetailPanel invoice={selectedInvoice} onPreview={setPreviewAttachment} /> : null}
+
+      {previewAttachment ? (
+        <AttachmentPreview attachment={previewAttachment} onClose={() => setPreviewAttachment(null)} />
+      ) : null}
+    </div>
+  );
+}
+
+type DetailPanelProps = {
+  invoice: InvoiceRecord;
+  onPreview: (attachment: InvoiceAttachment) => void;
+};
+
+function DetailPanel({ invoice, onPreview }: DetailPanelProps) {
+  return (
+    <div className="grid gap-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-200 md:grid-cols-[1.3fr_1fr]">
+      <div className="space-y-4">
+        <header className="space-y-2">
+          <h3 className="text-lg font-semibold text-white">{invoice.subject}</h3>
+          <p className="text-xs text-slate-400">
+            {invoice.invoiceNumber} ・ 発行日 {formatDate(invoice.issueDate)} ・ 最終更新 {formatDateTime(invoice.updatedAt)}
+          </p>
+        </header>
+
+        <dl className="grid grid-cols-2 gap-4 text-xs text-slate-300">
+          <div>
+            <dt className="text-slate-500">取引先</dt>
+            <dd className="mt-1 text-sm text-slate-100">{invoice.counterpartyName}</dd>
+            {invoice.counterpartyNumber ? (
+              <dd className="text-xs text-slate-500">{invoice.counterpartyNumber}</dd>
+            ) : null}
+          </div>
+          <div>
+            <dt className="text-slate-500">金額 (税込)</dt>
+            <dd className="mt-1 text-sm text-slate-100">
+              {formatCurrency(invoice.amountIncludingTax, invoice.currency)}
+            </dd>
+            <dd className="text-xs text-slate-500">税抜 {invoice.amountExcludingTax.toLocaleString()} {invoice.currency}</dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">状態</dt>
+            <dd className="mt-1">
+              <StatusBadge status={invoice.status} />
+            </dd>
+          </div>
+          <div>
+            <dt className="text-slate-500">対応メモ</dt>
+            <dd className="mt-1 text-slate-200">{invoice.remarks ?? "—"}</dd>
+          </div>
+          {invoice.matchedPurchaseOrder ? (
+            <div>
+              <dt className="text-slate-500">ひも付く購買</dt>
+              <dd className="mt-1 text-slate-200">{invoice.matchedPurchaseOrder}</dd>
+            </div>
+          ) : null}
+        </dl>
+      </div>
+
+      <aside className="space-y-4">
+        <h4 className="text-sm font-semibold text-white">添付ファイル</h4>
+        <div className="space-y-3">
+          {invoice.attachments.map((attachment) => (
+            <div
+              key={attachment.id}
+              className="rounded-lg border border-slate-800 bg-slate-950/80 p-4 text-xs text-slate-300"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-sm text-slate-100">{attachment.fileName}</p>
+                  <p className="text-slate-500">
+                    {attachment.mimeType} ・ {attachment.sizeLabel}
+                  </p>
+                </div>
+                <span className="rounded-md bg-slate-800 px-2 py-1 text-[10px] uppercase tracking-wide text-slate-400">
+                  {attachment.kind}
+                </span>
+              </div>
+              {attachment.previewNote ? (
+                <p className="mt-2 text-slate-400">{attachment.previewNote}</p>
+              ) : null}
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onPreview(attachment)}
+                  className="rounded-md border border-slate-700 bg-slate-900 px-3 py-1 text-xs text-slate-200 transition-colors hover:border-sky-500 hover:text-white"
+                >
+                  プレビュー
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md border border-slate-800 bg-slate-800 px-3 py-1 text-xs text-slate-400"
+                >
+                  ダウンロード
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+type AttachmentPreviewProps = {
+  attachment: InvoiceAttachment;
+  onClose: () => void;
+};
+
+function AttachmentPreview({ attachment, onClose }: AttachmentPreviewProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 p-4">
+      <div className="w-full max-w-xl space-y-4 rounded-2xl border border-slate-800 bg-slate-900 p-6 text-sm text-slate-200">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-base font-semibold text-white">{attachment.fileName}</h3>
+            <p className="text-xs text-slate-400">
+              {attachment.mimeType} ・ {attachment.sizeLabel}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-slate-700 bg-slate-950 px-3 py-1 text-xs text-slate-300 transition-colors hover:border-slate-500 hover:text-white"
+          >
+            閉じる
+          </button>
+        </header>
+        <div className="rounded-lg border border-slate-800 bg-slate-950 p-4 text-xs text-slate-300">
+          <p>プレビューは PoC 用のモック表示です。実装時には PDF / 画像ビューアを埋め込みます。</p>
+          {attachment.previewNote ? <p className="mt-2 text-slate-500">{attachment.previewNote}</p> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function buildQueryString(filters: InvoiceSearchFormState): string {
+  const params = new URLSearchParams();
+  if (filters.keyword.trim()) {
+    params.set("keyword", filters.keyword.trim());
+  }
+  if (filters.status !== "all") {
+    params.set("status", filters.status);
+  }
+  if (filters.startDate) {
+    params.set("issued_from", filters.startDate);
+  }
+  if (filters.endDate) {
+    params.set("issued_to", filters.endDate);
+  }
+  if (filters.minAmount.trim()) {
+    params.set("min_total", filters.minAmount.trim());
+  }
+  if (filters.maxAmount.trim()) {
+    params.set("max_total", filters.maxAmount.trim());
+  }
+  return params.toString();
+}
+
+function formatCurrency(value: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat("ja-JP", { style: "currency", currency }).format(value);
+  } catch (err) {
+    console.warn("[compliance] failed to format currency", err);
+    return `${value.toLocaleString()} ${currency}`;
+  }
+}
+
+function formatDate(date: string): string {
+  if (!date) return "—";
+  const parsed = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+  return parsed.toLocaleDateString("ja-JP", { year: "numeric", month: "short", day: "numeric" });
+}
+
+function formatDateTime(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function StatusBadge({ status }: { status: InvoiceRecord["status"] }) {
+  const color = badgeColor(status);
+  return (
+    <span
+      className={`${color} inline-flex items-center rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide`}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function badgeColor(status: InvoiceRecord["status"]): string {
+  switch (status) {
+    case "matched":
+      return "bg-emerald-500/20 text-emerald-200";
+    case "flagged":
+      return "bg-amber-500/20 text-amber-200";
+    case "pending":
+      return "bg-sky-500/20 text-sky-100";
+    case "archived":
+      return "bg-slate-700/50 text-slate-300";
+    default:
+      return "bg-slate-500/20 text-slate-200";
+  }
+}

--- a/ui-poc/src/features/compliance/mock-data.ts
+++ b/ui-poc/src/features/compliance/mock-data.ts
@@ -1,0 +1,167 @@
+import type { InvoiceListResponse, InvoiceRecord, InvoiceSearchFormState, InvoiceStatus } from "./types";
+
+const baseDate = new Date("2024-09-30T09:00:00+09:00");
+
+const items: InvoiceRecord[] = [
+  {
+    id: "inv-2024-0001",
+    invoiceNumber: "INV-2024-0001",
+    issueDate: "2024-09-25",
+    dueDate: "2024-10-10",
+    counterpartyName: "株式会社ライトニング",
+    counterpartyNumber: "LGT-0098",
+    subject: "9月度クラウド利用料",
+    amountIncludingTax: 550000,
+    amountExcludingTax: 500000,
+    currency: "JPY",
+    status: "matched",
+    tags: ["AWS", "サブスクリプション"],
+    remarks: "自動仕訳済み / ログID#241001-22",
+    matchedPurchaseOrder: "PO-2024-222",
+    attachments: [
+      {
+        id: "att-001",
+        kind: "pdf",
+        fileName: "INV-2024-0001.pdf",
+        mimeType: "application/pdf",
+        sizeLabel: "412KB",
+        previewNote: "PDF プレビューはモック表示です",
+      },
+      {
+        id: "att-002",
+        kind: "xml",
+        fileName: "INV-2024-0001.xml",
+        mimeType: "application/xml",
+        sizeLabel: "36KB",
+      },
+    ],
+    createdAt: "2024-09-25T10:03:00+09:00",
+    updatedAt: "2024-09-30T11:22:00+09:00",
+  },
+  {
+    id: "inv-2024-0002",
+    invoiceNumber: "INV-2024-0002",
+    issueDate: "2024-09-28",
+    dueDate: "2024-10-05",
+    counterpartyName: "日本エネルギー販売株式会社",
+    counterpartyNumber: "JPS-1204",
+    subject: "9月分電力使用料",
+    amountIncludingTax: 118800,
+    amountExcludingTax: 108000,
+    currency: "JPY",
+    status: "flagged",
+    tags: ["電力", "固定費"],
+    remarks: "単価変動あり。原本確認要",
+    attachments: [
+      {
+        id: "att-101",
+        kind: "pdf",
+        fileName: "INV-2024-0002.pdf",
+        mimeType: "application/pdf",
+        sizeLabel: "256KB",
+      },
+      {
+        id: "att-102",
+        kind: "image",
+        fileName: "meter-reading.png",
+        mimeType: "image/png",
+        sizeLabel: "1.2MB",
+        previewNote: "検針票サンプル画像",
+      },
+    ],
+    createdAt: "2024-09-28T13:12:00+09:00",
+    updatedAt: "2024-09-29T09:54:00+09:00",
+  },
+  {
+    id: "inv-2024-0003",
+    invoiceNumber: "INV-2024-0003",
+    issueDate: "2024-08-31",
+    dueDate: "2024-09-30",
+    counterpartyName: "Global Devices Ltd.",
+    counterpartyNumber: "GD-88",
+    subject: "Laptop refresh program",
+    amountIncludingTax: 1650000,
+    amountExcludingTax: 1500000,
+    currency: "JPY",
+    status: "registered",
+    tags: ["ハードウェア調達", "英語請求書"],
+    remarks: "為替差損考慮。入庫確認待ち",
+    attachments: [
+      {
+        id: "att-201",
+        kind: "pdf",
+        fileName: "INV-2024-0003.pdf",
+        mimeType: "application/pdf",
+        sizeLabel: "692KB",
+      },
+    ],
+    createdAt: "2024-08-31T08:43:00+09:00",
+    updatedAt: "2024-09-01T10:22:00+09:00",
+  },
+];
+
+export const mockInvoices: InvoiceListResponse = {
+  items,
+  meta: {
+    total: items.length,
+    fetchedAt: baseDate.toISOString(),
+    fallback: true,
+  },
+};
+
+export function searchMockInvoices(filters: InvoiceSearchFormState): InvoiceRecord[] {
+  const minAmount = Number.parseFloat(filters.minAmount);
+  const maxAmount = Number.parseFloat(filters.maxAmount);
+  const hasMin = Number.isFinite(minAmount);
+  const hasMax = Number.isFinite(maxAmount);
+  const keyword = filters.keyword.trim().toLowerCase();
+
+  return mockInvoices.items.filter((invoice) => {
+    if (filters.status !== "all" && invoice.status !== filters.status) {
+      return false;
+    }
+
+    if (filters.startDate && invoice.issueDate < filters.startDate) {
+      return false;
+    }
+    if (filters.endDate && invoice.issueDate > filters.endDate) {
+      return false;
+    }
+
+    if (hasMin && invoice.amountIncludingTax < minAmount) {
+      return false;
+    }
+    if (hasMax && invoice.amountIncludingTax > maxAmount) {
+      return false;
+    }
+
+    if (keyword) {
+      const haystack = [
+        invoice.invoiceNumber,
+        invoice.counterpartyName,
+        invoice.counterpartyNumber ?? "",
+        invoice.subject,
+        invoice.remarks ?? "",
+        invoice.tags.join(" "),
+      ]
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(keyword)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export function statusOptions(): Array<{ value: InvoiceStatus | "all"; label: string }> {
+  return [
+    { value: "all", label: "すべて" },
+    { value: "registered", label: "登録済み" },
+    { value: "pending", label: "処理待ち" },
+    { value: "matched", label: "照合済み" },
+    { value: "flagged", label: "要確認" },
+    { value: "archived", label: "保管済み" },
+  ];
+}

--- a/ui-poc/src/features/compliance/types.ts
+++ b/ui-poc/src/features/compliance/types.ts
@@ -1,0 +1,56 @@
+export type InvoiceStatus = "registered" | "pending" | "matched" | "flagged" | "archived";
+
+export const STATUS_LABEL: Record<InvoiceStatus, string> = {
+  registered: "登録済み",
+  pending: "処理待ち",
+  matched: "照合済み",
+  flagged: "要確認",
+  archived: "保管済み",
+};
+
+export type InvoiceAttachment = {
+  id: string;
+  kind: "pdf" | "image" | "xml";
+  fileName: string;
+  mimeType: string;
+  sizeLabel: string;
+  previewNote?: string;
+};
+
+export type InvoiceRecord = {
+  id: string;
+  invoiceNumber: string;
+  issueDate: string;
+  dueDate?: string;
+  counterpartyName: string;
+  counterpartyNumber?: string;
+  subject: string;
+  amountIncludingTax: number;
+  amountExcludingTax: number;
+  currency: string;
+  status: InvoiceStatus;
+  tags: string[];
+  remarks?: string;
+  matchedPurchaseOrder?: string;
+  attachments: InvoiceAttachment[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type InvoiceListResponse = {
+  items: InvoiceRecord[];
+  meta: {
+    total: number;
+    fetchedAt: string;
+    fallback: boolean;
+  };
+};
+
+export type InvoiceSearchFormState = {
+  keyword: string;
+  status: InvoiceStatus | "all";
+  startDate: string;
+  endDate: string;
+  minAmount: string;
+  maxAmount: string;
+};


### PR DESCRIPTION
## Summary
- 電子取引（インボイス）検索PoC画面を実装し、複合フィルタ・結果テーブル・詳細パネルを追加
- APIが利用できない場合にモックデータへ自動フォールバックする検索ロジックを追加
- READMEに  ルートで利用するPoC APIエンドポイントを追記

## Testing
- npm run lint
