### PR TITLE
test(ui-poc): PlaywrightによるPoC画面E2Eテスト

### DIFF
--- a/scripts/run_podman_ui_poc.sh
+++ b/scripts/run_podman_ui_poc.sh
@@ -56,4 +56,4 @@ echo "[ui] Starting Next.js dev server on port ${UI_PORT_VALUE}"
 echo "      (API base: http://localhost:${PM_PORT_VALUE})"
 NEXT_PUBLIC_API_BASE="http://localhost:${PM_PORT_VALUE}" \
 POC_API_BASE="http://localhost:${PM_PORT_VALUE}" \
-npm run dev -- --port "${UI_PORT_VALUE}"
+npm run dev -- --hostname 0.0.0.0 --port "${UI_PORT_VALUE}"

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -21,7 +21,7 @@ cp .env.local.example .env.local  # 必要に応じて API エンドポイント
    ```
 2. UI を起動
    ```bash
-   npm run dev -- --port 4000
+   npm run dev -- --hostname 0.0.0.0 --port 4000
    ```
 3. ブラウザで `http://localhost:4000` を開くと、各PoC画面へのナビゲーションを確認できます。
 
@@ -60,3 +60,8 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
 - `Timesheets` 画面: ステータスフィルタを切り替え → 行の操作ボタンで承認/差戻しを実施 → コメント入力や理由選択を試し、メッセージ表示の挙動を確認。
 - `Compliance` 画面: 期間/金額/ステータス/キーワードで検索条件を組み合わせ → 結果テーブルから行を選択 → 詳細パネルで添付プレビューを開き、モックビューアの流れを確認。
 - Podman 連携時: `scripts/run_podman_ui_poc.sh` でスタックを起動し、Real API モード (`API live` バッジ) とモックモード (`Mock data`) が自動で切り替わることを確認。
+
+## E2E テスト
+- 依存パッケージのインストール: `cd ui-poc && npm install`
+- Playwright ドライバの取得: `cd ui-poc && npx playwright install chromium`
+- テスト実行: `cd ui-poc && npm run test:e2e`

--- a/ui-poc/package-lock.json
+++ b/ui-poc/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -487,6 +488,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4245,6 +4262,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/ui-poc/package.json
+++ b/ui-poc/package.json
@@ -6,21 +6,23 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
+    "next": "14.2.5",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.2.5"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@playwright/test": "^1.55.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.5",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.5"
+    "typescript": "^5"
   }
 }

--- a/ui-poc/playwright.config.ts
+++ b/ui-poc/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   webServer: {
     command: `npm run dev -- --hostname 0.0.0.0 --port ${PORT}`,
-    url: `http://127.0.0.1:${PORT}`,
+    url: `http://${HOST}:${PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {

--- a/ui-poc/playwright.config.ts
+++ b/ui-poc/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.UI_PORT ?? '4000';
+const HOST = process.env.UI_HOST ?? '127.0.0.1';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://${HOST}:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npm run dev -- --hostname 0.0.0.0 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_API_BASE: process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3001',
+      POC_API_BASE: process.env.POC_API_BASE ?? 'http://localhost:3001',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/ui-poc/tests/e2e/compliance.spec.ts
+++ b/ui-poc/tests/e2e/compliance.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Compliance PoC', () => {
+  test('performs mock search and shows detail panel', async ({ page }) => {
+    await page.goto('/compliance');
+
+    await expect(page.getByRole('heading', { name: 'Compliance PoC' })).toBeVisible();
+    await expect(page.locator('table thead')).toContainText('請求書番号');
+
+    const firstRow = page.locator('table tbody tr').first();
+    await expect(firstRow).toBeVisible();
+
+    const subjectText = (await firstRow.locator('td').nth(3).innerText()).trim();
+
+    await firstRow.click();
+    await expect(page.getByRole('heading', { name: subjectText })).toBeVisible();
+
+    await page.getByPlaceholder('請求書番号 / 取引先 / タグ等').fill('Acme');
+    await page.getByRole('button', { name: '検索' }).click();
+    await expect(page.locator('table tbody tr').first()).toBeVisible();
+  });
+});

--- a/ui-poc/tests/e2e/compliance.spec.ts
+++ b/ui-poc/tests/e2e/compliance.spec.ts
@@ -10,7 +10,8 @@ test.describe('Compliance PoC', () => {
     const firstRow = page.locator('table tbody tr').first();
     await expect(firstRow).toBeVisible();
 
-    const subjectText = (await firstRow.locator('td').nth(3).innerText()).trim();
+    const SUBJECT_COLUMN_INDEX = 3;
+    const subjectText = (await firstRow.locator('td').nth(SUBJECT_COLUMN_INDEX).innerText()).trim();
 
     await firstRow.click();
     await expect(page.getByRole('heading', { name: subjectText })).toBeVisible();

--- a/ui-poc/tests/e2e/home.spec.ts
+++ b/ui-poc/tests/e2e/home.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home Navigation', () => {
+  test('displays overview and navigates to sections', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'UI PoC 概要' })).toBeVisible();
+    await expect(page.getByText('ITDO ERP3 UI PoC')).toBeVisible();
+
+    await page.getByRole('link', { name: 'Timesheets' }).click();
+    await expect(page).toHaveURL(/\/timesheets$/);
+  });
+});

--- a/ui-poc/tests/e2e/projects.spec.ts
+++ b/ui-poc/tests/e2e/projects.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Projects PoC', () => {
+  test('shows project cards and filters by status', async ({ page }) => {
+    await page.goto('/projects');
+
+    await expect(page.getByRole('heading', { name: 'Projects PoC' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible();
+
+    const firstCard = page.locator('article').first();
+    await expect(firstCard).toBeVisible();
+
+    await page.getByRole('button', { name: 'Planned' }).click();
+    await expect(page.locator('article').first()).toContainText('Planned');
+
+    await page.getByRole('button', { name: 'Active' }).click();
+    await expect(page.locator('article').first()).toContainText('Active');
+  });
+});

--- a/ui-poc/tests/e2e/timesheets.spec.ts
+++ b/ui-poc/tests/e2e/timesheets.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Timesheets PoC', () => {
+  test('displays timesheet table and actions', async ({ page }) => {
+    await page.goto('/timesheets');
+
+    await expect(page.getByRole('heading', { name: 'Timesheets PoC' })).toBeVisible();
+    await expect(page.locator('table thead')).toContainText('状態');
+
+    const rows = page.locator('table tbody tr');
+    await expect(rows.first()).toBeVisible();
+
+    const actionsCell = rows.first().locator('td').last();
+    await expect(actionsCell.getByRole('button').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Podman/UI同時起動スクリプトをWSL/Windowsアクセス対応として0.0.0.0バインドに変更
- Playwrightテスト基盤を追加し、Home/Projects/Timesheets/Complianceの基本操作を自動化
- READMEにWSLアクセスとE2Eテスト手順を追記

## Testing
- npm run lint
- npm run test:e2e
