### PR TITLE
fix(podman): allow custom host port for pm-service

### DIFF
--- a/poc/event-backbone/local/podman-compose.yml
+++ b/poc/event-backbone/local/podman-compose.yml
@@ -31,9 +31,9 @@ services:
       MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_BUCKET: ${MINIO_BUCKET:-events}
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
-      PORT: ${PM_PORT:-3001}
+      PORT: ${PM_CONTAINER_PORT:-3001}
     ports:
-      - "${PM_PORT:-3001}:3001"
+      - "${PM_PORT:-3001}:${PM_CONTAINER_PORT:-3001}"
     depends_on:
       - rabbitmq
       - redis

--- a/scripts/run_podman_ui_poc.sh
+++ b/scripts/run_podman_ui_poc.sh
@@ -5,7 +5,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_FILE="${ROOT_DIR}/poc/event-backbone/local/podman-compose.yml"
 PROJECT_DIR="${ROOT_DIR}/poc/event-backbone/local"
 UI_DIR="${ROOT_DIR}/ui-poc"
-PM_PORT_VALUE="${PM_PORT:-3001}"
+PM_HOST_PORT="${PM_PORT:-3001}"
+PM_CONTAINER_PORT="${PM_CONTAINER_PORT:-3001}"
 UI_PORT_VALUE="${UI_PORT:-4000}"
 
 if ! command -v podman-compose >/dev/null 2>&1; then
@@ -23,6 +24,10 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
+# Export variables for podman-compose so that host/container port values are respected.
+export PM_PORT="${PM_HOST_PORT}"
+export PM_CONTAINER_PORT
+
 cleanup() {
   printf '\n[cleanup] Stopping UI PoC stack...\n'
   (cd "${PROJECT_DIR}" && podman-compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1) || true
@@ -35,10 +40,10 @@ cd "${PROJECT_DIR}"
 echo "[podman] Starting backend PoC stack via podman-compose"
 podman-compose -f "${COMPOSE_FILE}" up -d --build
 
-echo "[health] Waiting for pm-service on http://localhost:${PM_PORT_VALUE}"
+echo "[health] Waiting for pm-service on http://localhost:${PM_HOST_PORT}"
 pm_service_up=false
 for _ in {1..40}; do
-  if curl -fsS "http://localhost:${PM_PORT_VALUE}/health" >/dev/null 2>&1; then
+  if curl -fsS "http://localhost:${PM_HOST_PORT}/health" >/dev/null 2>&1; then
     pm_service_up=true
     break
   fi
@@ -53,7 +58,7 @@ fi
 cd "${UI_DIR}"
 
 echo "[ui] Starting Next.js dev server on port ${UI_PORT_VALUE}"
-echo "      (API base: http://localhost:${PM_PORT_VALUE})"
-NEXT_PUBLIC_API_BASE="http://localhost:${PM_PORT_VALUE}" \
-POC_API_BASE="http://localhost:${PM_PORT_VALUE}" \
+echo "      (API base: http://localhost:${PM_HOST_PORT})"
+NEXT_PUBLIC_API_BASE="http://localhost:${PM_HOST_PORT}" \
+POC_API_BASE="http://localhost:${PM_HOST_PORT}" \
 npm run dev -- --hostname 0.0.0.0 --port "${UI_PORT_VALUE}"

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -33,7 +33,7 @@ cp .env.local.example .env.local  # 必要に応じて API エンドポイント
 scripts/run_podman_ui_poc.sh
 ```
 
-環境変数 `PM_PORT` (既定 3001) と `UI_PORT` (既定 4000) を指定するとポートを変更できます。
+環境変数 `PM_PORT` (ホスト側の公開ポート、既定 3001) と `UI_PORT` (既定 4000) を指定するとポートを変更できます。必要に応じて `PM_CONTAINER_PORT` でコンテナ内ポートも調整できますが、通常は既定の 3001 のままで問題ありません。
 
 ```bash
 PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh


### PR DESCRIPTION
## Summary
- decouple pm-service container port from host mapping so  only affects the host-side binding
- export  (default 3001) from helper scripts before running podman-compose
- document the distinction in the UI PoC README

## Testing
- (manual) scripts/run_podman_ui_poc.sh with default ports
- (manual) PM_PORT=3101 scripts/run_podman_poc.sh (after change)
