### PR TITLE
feat(poc): persist pm-service state and improve tooling

### DIFF
--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -60,10 +60,10 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
 - `Timesheets` 画面: ステータスフィルタを切り替え → 行の操作ボタンで承認/差戻しを実施 → コメント入力や理由選択を試し、メッセージ表示の挙動を確認。
 - `Compliance` 画面: 期間/金額/ステータス/キーワードで検索条件を組み合わせ → 結果テーブルから行を選択 → 詳細パネルで添付プレビューを開き、モックビューアの流れを確認。
 - Podman 連携時: `scripts/run_podman_ui_poc.sh` でスタックを起動し、Real API モード (`API live` バッジ) とモックモード (`Mock data`) が自動で切り替わることを確認。
-  - Podman スタックを起動している場合、プロジェクト/タイムシート/電子取引の PoC API が `/api/v1/...` エンドポイントからサンプルデータを返します。
+  - Podman スタックを起動している場合、プロジェクト/タイムシート/電子取引の PoC API が `/api/v1/...` エンドポイントからサンプルデータを返します。`/api/v1/projects`・`/api/v1/timesheets` の `POST` で追加、`DELETE /api/v1/timesheets/:id` で削除、`/metrics/summary` や `/events/recent` で状況を確認できます。
 
 ## E2E テスト
 - 依存パッケージのインストール: `cd ui-poc && npm install`
 - Playwright ドライバの取得: `cd ui-poc && npx playwright install chromium`
 - テスト実行: `cd ui-poc && npm run test:e2e`
-- Podman を起動して API 連携（`API live` バッジ）を確認したい場合は `E2E_EXPECT_API=true npm run test:e2e` を利用してください。
+- Podman を起動して API 連携（`API live` バッジ）を確認したい場合は `npm run test:e2e:live` を利用してください。

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -27,13 +27,13 @@ cp .env.local.example .env.local  # 必要に応じて API エンドポイント
 
 ### Podman + UI をまとめて起動する場合
 
-バックエンド PoC と Next.js Dev Server を同時に立ち上げる補助スクリプトも用意しています（事前に `podman-compose` / `npm` / `curl` が利用可能なことを確認してください）。
+バックエンド PoC と Next.js Dev Server を同時に立ち上げる補助スクリプトも用意しています（事前に `podman-compose` / `npm` / `curl` が利用可能なことを確認してください）。UI 用ポートが使用中の場合はスクリプトが警告を出して終了するので、別ポートを `UI_PORT` で指定するか該当プロセスを停止してください。
 
 ```bash
 scripts/run_podman_ui_poc.sh
 ```
 
-環境変数 `PM_PORT` (ホスト側の公開ポート、既定 3001) と `UI_PORT` (既定 4000) を指定するとポートを変更できます。必要に応じて `PM_CONTAINER_PORT` でコンテナ内ポートも調整できますが、通常は既定の 3001 のままで問題ありません。
+環境変数 `PM_PORT` (ホスト側の公開ポート、既定 3001) と `UI_PORT` (既定 4000) を指定するとポートを変更できます。必要に応じて `PM_CONTAINER_PORT` でコンテナ内ポートも調整できますが、通常は既定の 3001 のままで問題ありません。PoC API サービスは `/app/state/pm-poc-state.json`（`PM_STATE_FILE` で変更可）に状態を永続化するため、Podman を再起動しても最新状態が復元されます。
 
 ```bash
 PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
@@ -66,3 +66,4 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
 - 依存パッケージのインストール: `cd ui-poc && npm install`
 - Playwright ドライバの取得: `cd ui-poc && npx playwright install chromium`
 - テスト実行: `cd ui-poc && npm run test:e2e`
+- Podman を起動して API 連携（`API live` バッジ）を確認したい場合は `E2E_EXPECT_API=true npm run test:e2e` を利用してください。

--- a/ui-poc/tests/e2e/api-live.spec.ts
+++ b/ui-poc/tests/e2e/api-live.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+const REQUIRE_API = process.env.E2E_EXPECT_API === 'true';
+
+test.describe('API Live Integration', () => {
+  test.skip(!REQUIRE_API, 'Set E2E_EXPECT_API=true to run API live checks.');
+
+  test('timesheets/projects/compliance show API live badge', async ({ page }) => {
+    await page.goto('/timesheets');
+    await expect(page.getByText('API live')).toBeVisible();
+
+    await page.goto('/projects');
+    await expect(page.getByText('API live')).toBeVisible();
+
+    await page.goto('/compliance');
+    await expect(page.getByText('API live')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- persist pm-service projects/timesheets/invoices to `state/pm-poc-state.json` so Podman再起動後も状態を復元
- add port availability check to `scripts/run_podman_ui_poc.sh` to guide reusing UI_PORT safely
- add optional Playwright scenario (`E2E_EXPECT_API=true`) for API live badge
- document new behaviour (state file, optional test, port guidance)

## Testing
- npm run test:e2e
- PM_PORT=3101 PM_CONTAINER_PORT=3001 podman-compose up -d (pm-service) and manual API/イベント確認
