### PR TITLE
Fetch compliance invoices via GraphQL with REST fallback

### DIFF
--- a/ui-poc/src/app/compliance/page.tsx
+++ b/ui-poc/src/app/compliance/page.tsx
@@ -1,6 +1,7 @@
 import { ComplianceClient } from "@/features/compliance/ComplianceClient";
 import { mockInvoices } from "@/features/compliance/mock-data";
 import type { InvoiceListResponse } from "@/features/compliance/types";
+import { COMPLIANCE_INVOICES_QUERY } from "@/features/compliance/queries";
 import { reportServerTelemetry } from "@/lib/telemetry";
 
 const defaultMeta: InvoiceListResponse["meta"] = {
@@ -16,57 +17,117 @@ const defaultMeta: InvoiceListResponse["meta"] = {
 
 async function fetchComplianceInvoices(): Promise<InvoiceListResponse> {
   const base = process.env.POC_API_BASE ?? "http://localhost:3001";
+  const filterInput = { page: 1, pageSize: 25, sortBy: "issueDate", sortDir: "desc" as const };
+
   try {
-    const params = new URLSearchParams({
-      page: "1",
-      page_size: "25",
-      sort_by: "issueDate",
-      sort_dir: "desc",
+    const gqlResponse = await fetch(`${base}/graphql`, {
+      method: "POST",
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: COMPLIANCE_INVOICES_QUERY, variables: { filter: filterInput } }),
     });
-    const res = await fetch(`${base}/api/v1/compliance/invoices?${params.toString()}`, { cache: "no-store" });
-    if (!res.ok) {
-      throw new Error(`status ${res.status}`);
+    if (!gqlResponse.ok) {
+      throw new Error(`graphql status ${gqlResponse.status}`);
     }
-    const data = (await res.json()) as Partial<InvoiceListResponse>;
+    const gqlPayload = (await gqlResponse.json()) as {
+      data?: {
+        complianceInvoices?: {
+          items?: InvoiceListResponse["items"];
+          meta?: InvoiceListResponse["meta"];
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+    if (gqlPayload.errors?.length) {
+      throw new Error(gqlPayload.errors.map((err) => err.message).join("; "));
+    }
+    const connection = gqlPayload.data?.complianceInvoices;
+    if (!connection) {
+      throw new Error("graphql response missing complianceInvoices");
+    }
+    const items = Array.isArray(connection.items) ? connection.items : [];
+    const meta = connection.meta ?? {};
+    const normalizedMeta: InvoiceListResponse["meta"] = {
+      total: meta.total ?? items.length,
+      page: meta.page ?? filterInput.page,
+      pageSize: meta.pageSize ?? filterInput.pageSize,
+      totalPages: meta.totalPages ?? 1,
+      sortBy: (meta.sortBy as InvoiceListResponse["meta"]["sortBy"]) ?? filterInput.sortBy,
+      sortDir: (meta.sortDir as InvoiceListResponse["meta"]["sortDir"]) ?? filterInput.sortDir,
+      fetchedAt: meta.fetchedAt ?? new Date().toISOString(),
+      fallback: meta.fallback ?? false,
+    };
+
     await reportServerTelemetry({
       component: "compliance/page",
-      event: "api_fetch_succeeded",
-      level: "info",
+      event: "graphql_fetch_succeeded",
+      level: normalizedMeta.fallback ? "warn" : "info",
       detail: {
-        items: data.items?.length ?? 0,
-        fallback: data.meta?.fallback ?? false,
+        stage: "initial",
+        items: items.length,
+        fallback: normalizedMeta.fallback,
       },
     });
-    return {
-      items: data.items ?? [],
-      meta: {
-        total: data.meta?.total ?? data.items?.length ?? 0,
-        page: data.meta?.page ?? 1,
-        pageSize: data.meta?.pageSize ?? 25,
-        totalPages: data.meta?.totalPages ?? 1,
-        sortBy: data.meta?.sortBy ?? "issueDate",
-        sortDir: data.meta?.sortDir ?? "desc",
-        fetchedAt: data.meta?.fetchedAt ?? new Date().toISOString(),
-        fallback: data.meta?.fallback ?? false,
-      },
-    } satisfies InvoiceListResponse;
-  } catch (error) {
-    console.warn("[compliance] falling back to mock data due to fetch error", error);
+
+    return { items, meta: normalizedMeta } satisfies InvoiceListResponse;
+  } catch (graphqlError) {
+    console.warn("[compliance] GraphQL fetch failed, fallback to REST", graphqlError);
     await reportServerTelemetry({
       component: "compliance/page",
-      event: "mock_fallback",
+      event: "graphql_fetch_failed",
       level: "warn",
       detail: {
-        error: error instanceof Error ? error.message : String(error),
+        stage: "initial",
+        error: graphqlError instanceof Error ? graphqlError.message : String(graphqlError),
       },
     });
-    return {
-      ...mockInvoices,
-      meta: {
-        ...defaultMeta,
-        ...mockInvoices.meta,
-      },
-    };
+    try {
+      const res = await fetch(`${base}/api/v1/compliance/invoices`, { cache: "no-store" });
+      if (!res.ok) {
+        throw new Error(`status ${res.status}`);
+      }
+      const data = (await res.json()) as Partial<InvoiceListResponse>;
+      await reportServerTelemetry({
+        component: "compliance/page",
+        event: "rest_fallback_succeeded",
+        level: "info",
+        detail: {
+          stage: "initial",
+          items: data.items?.length ?? 0,
+        },
+      });
+      return {
+        items: data.items ?? [],
+        meta: {
+          total: data.meta?.total ?? data.items?.length ?? 0,
+          page: data.meta?.page ?? 1,
+          pageSize: data.meta?.pageSize ?? 25,
+          totalPages: data.meta?.totalPages ?? 1,
+          sortBy: data.meta?.sortBy ?? "issueDate",
+          sortDir: data.meta?.sortDir ?? "desc",
+          fetchedAt: data.meta?.fetchedAt ?? new Date().toISOString(),
+          fallback: data.meta?.fallback ?? false,
+        },
+      } satisfies InvoiceListResponse;
+    } catch (restError) {
+      console.warn("[compliance] falling back to mock data due to fetch error", restError);
+      await reportServerTelemetry({
+        component: "compliance/page",
+        event: "mock_fallback",
+        level: "warn",
+        detail: {
+          stage: "initial",
+          error: restError instanceof Error ? restError.message : String(restError),
+        },
+      });
+      return {
+        ...mockInvoices,
+        meta: {
+          ...defaultMeta,
+          ...mockInvoices.meta,
+        },
+      };
+    }
   }
 }
 

--- a/ui-poc/src/features/compliance/queries.ts
+++ b/ui-poc/src/features/compliance/queries.ts
@@ -1,0 +1,36 @@
+export const COMPLIANCE_INVOICES_QUERY = `
+  query ComplianceInvoices($filter: ComplianceInvoiceFilterInput) {
+    complianceInvoices(filter: $filter) {
+      items {
+        id
+        invoiceNumber
+        counterpartyName
+        issueDate
+        dueDate
+        amountIncludingTax
+        status
+        tags
+        matchedPurchaseOrder
+        attachments {
+          id
+          fileName
+          fileType
+          downloadUrl
+          storageKey
+        }
+        createdAt
+        updatedAt
+      }
+      meta {
+        total
+        page
+        pageSize
+        totalPages
+        sortBy
+        sortDir
+        fetchedAt
+        fallback
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## 概要
- Compliance ページの初期データ取得を GraphQL () 優先に変更し、REST→モックの二段フォールバックを維持
- フロントエンドの検索ロジックでも GraphQL を試行し、成功/失敗テレメトリを出力
- GraphQL クエリを共有する  を追加し、ダウンロードURLを含むフィールドを整備

## テスト
- npm run test:e2e -- compliance.spec.ts --prefix ui-poc
