### PR TITLE
Refactor: Telemetry filtersの初期化と永続化を安定化

### DIFF
--- a/ui-poc/src/contexts/telemetry/TelemetryFiltersContext.tsx
+++ b/ui-poc/src/contexts/telemetry/TelemetryFiltersContext.tsx
@@ -25,19 +25,7 @@ const buildInitialSnapshot = (initial?: TelemetryFilters): TelemetryFilters => (
 });
 
 export function TelemetryFiltersProvider({ initialFilters, children }: { initialFilters?: TelemetryFilters; children: ReactNode }) {
-  const initialSnapshot = useMemo(
-    () => buildInitialSnapshot(initialFilters),
-    [
-      initialFilters?.component,
-      initialFilters?.event,
-      initialFilters?.detail,
-      initialFilters?.detailPath,
-      initialFilters?.level,
-      initialFilters?.origin,
-      initialFilters?.sort,
-      initialFilters?.order,
-    ],
-  );
+  const initialSnapshot = useMemo(() => buildInitialSnapshot(initialFilters), [initialFilters]);
 
   const { formFilters, setFormFilters, persistFilters, readFromStorage } = useTelemetryFilters(initialSnapshot);
   const [filters, setFiltersState] = useState<TelemetryFilters>(initialSnapshot);
@@ -56,19 +44,7 @@ export function TelemetryFiltersProvider({ initialFilters, children }: { initial
     setFiltersState(merged);
     setFormFilters(merged);
     persistFilters(merged);
-  }, [
-    initialSnapshot.component,
-    initialSnapshot.event,
-    initialSnapshot.detail,
-    initialSnapshot.detailPath,
-    initialSnapshot.level,
-    initialSnapshot.origin,
-    initialSnapshot.sort,
-    initialSnapshot.order,
-    persistFilters,
-    readFromStorage,
-    setFormFilters,
-  ]);
+  }, [initialSnapshot, persistFilters, readFromStorage, setFormFilters]);
 
   const applyFilters = useCallback(
     (next: TelemetryFilters) => {


### PR DESCRIPTION
## 概要
- TelemetryFiltersProvider の初期値計算を簡素化し依存関係警告を解消
- useTelemetryFilters で初期値マージロジックを一本化し、localStorage 読み書きを整理
- lint 警告が出ないよう hook 依存を明示

## テスト
- npm run lint
- npm run test:e2e
