### PR TITLE
Chore: Makefileでライブ検証を簡素化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+PM_PORT ?= 3001
+UI_PORT ?= 4000
+UI_HEADLESS ?= false
+FORCE_PM_PORT ?= 3001
+
+default: help
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  make live-tests              # Run Podman stack with current settings and execute Playwright live tests"
+	@echo "  make live-tests-minio        # Run live tests with MinIO enabled (USE_MINIO/E2E_REQUIRE_MINIO)"
+	@echo "  make lint                    # Run UI lint"
+	@echo "  make test-e2e                # Run UI Playwright E2E tests"
+
+.PHONY: live-tests
+live-tests:
+	FORCE_PM_PORT=$(FORCE_PM_PORT) PM_PORT=$(PM_PORT) UI_PORT=$(UI_PORT) UI_HEADLESS=$(UI_HEADLESS) scripts/run_podman_ui_poc.sh --tests-only
+
+.PHONY: live-tests-minio
+live-tests-minio:
+	FORCE_PM_PORT=$(FORCE_PM_PORT) USE_MINIO=true E2E_REQUIRE_MINIO=true PM_PORT=$(PM_PORT) UI_PORT=$(UI_PORT) UI_HEADLESS=$(UI_HEADLESS) scripts/run_podman_ui_poc.sh --tests-only
+
+.PHONY: lint
+lint:
+	cd ui-poc && npm run lint
+
+.PHONY: test-e2e
+test-e2e:
+	cd ui-poc && npm run test:e2e

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -10,17 +10,18 @@
 
 ## 2. ローカルでのライブ検証
 ```bash
-# MinIO 有効・PM ポートを 3101 に変更した上でライブテストのみ実行
-FORCE_PM_PORT=3001 \
-  USE_MINIO=true \
-  PM_PORT=3101 \
-  UI_PORT=4100 \
-  UI_HEADLESS=true \
-  scripts/run_podman_ui_poc.sh --tests-only
+# デフォルト設定でライブテストのみ実行
+make live-tests
+
+# MinIO 署名 URL を必須にしたい場合
+make live-tests-minio PM_PORT=3101 UI_PORT=4100 UI_HEADLESS=true
+
+# 直接スクリプトを呼び出したい場合
+FORCE_PM_PORT=3001 USE_MINIO=true PM_PORT=3101 UI_PORT=4100 UI_HEADLESS=true scripts/run_podman_ui_poc.sh --tests-only
 ```
 
 - `FORCE_PM_PORT=3001` : Playwright ライブテストを既定ポート 3001 で実行するためにスタックを再起動します。
-- `USE_MINIO=true` : MinIO サービスを有効化し、署名付き URL の生成をテストします。
+- `USE_MINIO=true` : MinIO サービスを有効化し、署名付き URL の生成をテストします（`make live-tests-minio` が自動で付与）。
 - `SKIP_GRAPHQL_PREFLIGHT=true` を指定すると、GraphQL ウォームアップをスキップして素早くテストに入れます（起動直後の 400 応答が気になる場合は `false` のままにしてください）。
 - `E2E_REQUIRE_MINIO=true` を併用すると、Playwright が MinIO 署名 URL の有無を検証します。
 

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -95,6 +95,7 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
 - Playwright ドライバの取得: `cd ui-poc && npx playwright install chromium`
 - テスト実行: `cd ui-poc && npm run test:e2e`
 - Podman を起動して API 連携（`API live` バッジ）を確認したい場合は `npm run test:e2e:live` を利用してください。MinIO を必須として検証する場合は `E2E_REQUIRE_MINIO=true` を併用し、GraphQL ウォームアップを無効化したいときは `SKIP_GRAPHQL_PREFLIGHT=true` を指定します。
+- ルートディレクトリの `Makefile` から `make live-tests` / `make live-tests-minio` を用いると、環境変数を毎回指定せずに Podman ライブ検証を実行できます。
 - GitHub Actions の `api-live-minio` ワークフローを実行すると、MinIO 有効化 (`USE_MINIO=true`) と署名付き URL 検証 (`E2E_REQUIRE_MINIO=true`) を含む Podman ベースのライブシナリオを CI 上で確認できます。
 - `npm run test:e2e` は Telemetry 再試行バナーと SSE の動作モック（`tests/e2e/metrics.spec.ts`）も検証します。ライブ API と組み合わせる場合は `E2E_EXPECT_API=true` を設定してください。
 


### PR DESCRIPTION
## 概要
- ルートに `Makefile` を追加し、`make live-tests` / `make live-tests-minio` などで Podman ライブ検証を実行できるようにしました
- `docs/live-testing.md` を更新し、Makefile を利用する手順を追記
- `ui-poc/README.md` に Makefile ターゲットの案内を追加

## テスト
- npm run lint
