### PR TITLE
feat: Projects/Timesheets のキーワード検索対応

### DIFF
--- a/poc/event-backbone/local/services/pm-service/graphql-schema.js
+++ b/poc/event-backbone/local/services/pm-service/graphql-schema.js
@@ -301,15 +301,30 @@ export function createGraphQLSchema({
         args: {
           status: { type: GraphQLString },
           projectId: { type: GraphQLString },
+          keyword: { type: GraphQLString },
         },
         resolve: (_root, args) => {
           const status = typeof args?.status === 'string' ? args.status.trim().toLowerCase() : '';
           const projectId = typeof args?.projectId === 'string' ? args.projectId.trim() : '';
+          const keyword = typeof args?.keyword === 'string' ? args.keyword.trim().toLowerCase() : '';
           const filteredTimesheets = timesheets.filter((sheet) => {
             const statusMatch = !status || status === 'all' || sheet.approvalStatus === status;
             if (!statusMatch) return false;
-            if (!projectId) return true;
-            return sheet.projectId === projectId || sheet.projectCode === projectId;
+            const projectMatch =
+              !projectId || sheet.projectId === projectId || sheet.projectCode === projectId;
+            if (!projectMatch) return false;
+            if (!keyword) return true;
+            const haystack = [
+              sheet.projectCode,
+              sheet.projectName,
+              sheet.userName,
+              sheet.note,
+              sheet.taskName,
+            ]
+              .filter(Boolean)
+              .join(' ')
+              .toLowerCase();
+            return haystack.includes(keyword);
           });
           return cloneDeep(filteredTimesheets);
         },

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -77,7 +77,9 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
   }
   ```
 - Projects 画面には GraphQL 経由の「プロジェクト追加」フォームを実装しており、作成・状態遷移は GraphQL ミューテーションを優先的に利用します（失敗時は REST にフォールバック）。
+- Projects 画面の一覧にはキーワード検索バーを追加しており、GraphQL `projects(status, keyword)` でフィルタ済みデータを取得します。GraphQL が失敗した場合は REST → モックデータの順にフォールバックしつつテレメトリへ記録します。
 - Timesheets 画面にも GraphQL のクイック追加フォームと、承認/差戻しアクションの GraphQL 呼び出しが組み込まれています。
+- Timesheets 画面のテーブルはステータスとキーワードで絞り込み可能になり、GraphQL `timesheets(status, keyword)` を優先利用します（フォールバック時は REST 応答をクライアント側で再フィルタリングし、最終的にモックへ切り替えます）。
 - Compliance 画面は GraphQL クエリ `complianceInvoices` を優先利用しており、ページネーション/フィルタ結果のメタ情報を取得できます。
 - GraphQL / REST の両経路は Idempotency-Key をサポートしており、UI クライアント側ではフォールバック時に `reportClientTelemetry` / `reportServerTelemetry` を発火して動作状況を記録します。Podman スタックが起動していれば Telemetry イベントは Loki へ転送され、`scripts/show_telemetry.js` で最新イベントを確認できます。
 - `/telemetry` ページでは Component/Event/Detail/Level/Origin を条件にフィルタし、15 秒間隔で自動更新が行われます。並び順は `Sort` / `Order` セレクトから変更でき、`?pollMs=1000` や `NEXT_PUBLIC_TELEMETRY_POLL_MS` でポーリング間隔も調整可能です。フィルタ設定は URL クエリと localStorage に記録され再訪時に復元されます。

--- a/ui-poc/src/features/compliance/queries.ts
+++ b/ui-poc/src/features/compliance/queries.ts
@@ -15,6 +15,7 @@ export const COMPLIANCE_INVOICES_QUERY = `#graphql
         tags
         remarks
         matchedPurchaseOrder
+        subject
         attachments {
           id
           kind
@@ -81,6 +82,7 @@ export const COMPLIANCE_INVOICES_QUERY_LIVE = `#graphql
         currency
         status
         matchedPurchaseOrder
+        subject
         attachments {
           id
           kind

--- a/ui-poc/src/features/projects/queries.ts
+++ b/ui-poc/src/features/projects/queries.ts
@@ -1,6 +1,6 @@
 export const PROJECTS_PAGE_QUERY = `#graphql
-  query ProjectsPage($status: String) {
-    projects(status: $status) {
+  query ProjectsPage($status: String, $keyword: String) {
+    projects(status: $status, keyword: $keyword) {
       id
       code
       name

--- a/ui-poc/src/features/timesheets/queries.ts
+++ b/ui-poc/src/features/timesheets/queries.ts
@@ -1,6 +1,6 @@
 export const TIMESHEETS_PAGE_QUERY = `#graphql
-  query TimesheetsPage($status: String) {
-    timesheets(status: $status) {
+  query TimesheetsPage($status: String, $keyword: String) {
+    timesheets(status: $status, keyword: $keyword) {
       id
       userName
       projectCode

--- a/ui-poc/tests/e2e/compliance.spec.ts
+++ b/ui-poc/tests/e2e/compliance.spec.ts
@@ -13,7 +13,9 @@ test.describe('Compliance PoC', () => {
     await expect(firstRow).toBeVisible();
 
     const SUBJECT_COLUMN_INDEX = 3;
-    const subjectText = (await firstRow.locator('td').nth(SUBJECT_COLUMN_INDEX).innerText()).trim();
+    const subjectCell = firstRow.locator('td').nth(SUBJECT_COLUMN_INDEX);
+    await expect(subjectCell).not.toHaveText('');
+    const subjectText = (await subjectCell.innerText()).trim();
 
     await firstRow.click();
     await expect(page.getByRole('heading', { name: subjectText })).toBeVisible();
@@ -30,7 +32,9 @@ test.describe('Compliance PoC', () => {
     await expect(meta).toContainText('ヒット件数');
 
     await page.getByLabel('並び順 (項目)').selectOption('amount');
-    await expect(page.locator('table tbody tr').first().locator('td').nth(3)).toContainText(/Laptop refresh program|Laptop/i);
+    const firstAmountCell = page.locator('table tbody tr').first().locator('td').nth(3);
+    await expect(firstAmountCell).not.toHaveText('');
+    await expect(firstAmountCell).toContainText(/Laptop refresh program|Laptop/i);
 
     await page.getByLabel('並び順 (方向)').selectOption('asc');
     await expect(page.locator('table tbody tr').first().locator('td').nth(3)).toContainText(/電力使用料|電力|Laptop refresh program/i);


### PR DESCRIPTION
## 概要
- Projects 画面にキーワード検索フォームを追加し、GraphQL `projects(status, keyword)` を利用して再取得するようにしました（失敗時は REST→モックの順でフォールバック）
- Timesheets 画面でもキーワード検索とステータス変更で GraphQL 再取得するようにし、REST フォールバック時はクライアント側で再フィルタリングします
- pm-service の GraphQL スキーマに timesheets(keyword) を追加し、キーワードフィルタの Jest テストを追加しました
- Playwright テストを検索シナリオに対応させ、Compliance クエリで subject を返すよう修正しました

## テスト
- npm run lint
- (cd poc/event-backbone/local/services/pm-service && npm test)
- npm run test:e2e
