### PR TITLE
feat: Timesheetsサマリとテレメトリ改善

### DIFF
--- a/ui-poc/src/features/timesheets/TimesheetsClient.tsx
+++ b/ui-poc/src/features/timesheets/TimesheetsClient.tsx
@@ -93,6 +93,17 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
 
   const source: QuerySource = meta.fallback ? "mock" : "api";
 
+  const statusLabel = useMemo(() => {
+    if (filter === "all") {
+      return "すべて";
+    }
+    return STATUS_LABEL[filter];
+  }, [filter]);
+
+  const keywordSummary = appliedKeyword.trim().length > 0 ? `"${appliedKeyword}"` : "指定なし";
+  const apiReturned = meta.returned ?? timesheets.length;
+  const apiTotal = meta.total ?? timesheets.length;
+
   const filtered = useMemo(() => {
     const keyword = appliedKeyword.trim().toLowerCase();
     return timesheets.filter((entry) => {
@@ -196,6 +207,19 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
           false,
           statusValue === "all" ? "all" : (statusValue as TimesheetStatus),
         );
+        reportClientTelemetry({
+          component: "timesheets/client",
+          event: "list_fetch_succeeded",
+          level: "info",
+          detail: {
+            strategy: "graphql",
+            status: statusValue,
+            keyword: trimmedKeyword,
+            returned: normalized.length,
+            total: normalized.length,
+            fallback: false,
+          },
+        });
         finishLoading();
         return;
       } catch (error) {
@@ -230,6 +254,19 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
         );
         reportClientTelemetry({
           component: "timesheets/client",
+          event: "list_fetch_succeeded",
+          level: "info",
+          detail: {
+            strategy: "rest",
+            status: statusValue,
+            keyword: trimmedKeyword,
+            returned: normalized.length,
+            total: rest.meta?.total ?? normalized.length,
+            fallback: rest.meta?.fallback ?? false,
+          },
+        });
+        reportClientTelemetry({
+          component: "timesheets/client",
           event: "rest_list_fallback",
           level: "info",
           detail: {
@@ -256,6 +293,19 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
           .map((entry) => normalizeTimesheet(entry))
           .filter(Boolean) as TimesheetEntry[];
         assignTimesheets(fallbackItems, true, "all");
+        reportClientTelemetry({
+          component: "timesheets/client",
+          event: "list_fetch_succeeded",
+          level: "info",
+          detail: {
+            strategy: "mock",
+            status: statusValue,
+            keyword: trimmedKeyword,
+            returned: fallbackItems.length,
+            total: fallbackItems.length,
+            fallback: true,
+          },
+        });
         finishLoading();
       }
     },
@@ -668,10 +718,14 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
       </form>
 
       <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
-        <span>
-          表示件数: {filtered.length.toLocaleString()} / {meta.total.toLocaleString()} 件
+        <span data-testid="timesheets-summary-count">
+          表示件数: {filtered.length.toLocaleString()} 件 ({apiReturned.toLocaleString()} / {apiTotal.toLocaleString()} 件)
+        </span>
+        <span data-testid="timesheets-summary-filters">
+          フィルタ: {statusLabel} / キーワード: {keywordSummary}
         </span>
         <span>取得時刻: {formatDateTime(meta.fetchedAt)}</span>
+        {meta.status ? <span>APIステータス: {meta.status}</span> : null}
         <span
           className={`rounded-full px-2 py-1 font-medium ${
             source === "api" ? "bg-emerald-500/20 text-emerald-200" : "bg-amber-500/20 text-amber-200"

--- a/ui-poc/tests/e2e/timesheets.spec.ts
+++ b/ui-poc/tests/e2e/timesheets.spec.ts
@@ -14,6 +14,9 @@ test.describe('Timesheets PoC', () => {
 
     const actionsCell = rows.first().locator('td').last();
     await expect(actionsCell.getByRole('button').first()).toBeVisible();
+
+    await expect(page.getByTestId('timesheets-summary-count')).toContainText('表示件数');
+    await expect(page.getByTestId('timesheets-summary-filters')).toContainText('フィルタ');
   });
 
   test('filters timesheets by keyword search', async ({ page }) => {
@@ -89,9 +92,11 @@ test.describe('Timesheets PoC', () => {
     await page.getByRole('button', { name: '検索' }).click();
     await expect(page.locator('table tbody tr')).toHaveCount(1);
     await expect(page.locator('table tbody tr').first()).toContainText('Analytics Platform');
+    await expect(page.getByTestId('timesheets-summary-filters')).toContainText('"Analytics"');
 
     await page.getByRole('button', { name: 'クリア' }).click();
     await expect(page.locator('table tbody tr')).toHaveCount(2);
+    await expect(page.getByTestId('timesheets-summary-filters')).toContainText('指定なし');
   });
 
   test('adds and approves timesheet via GraphQL form with API stubs', async ({ page }) => {
@@ -191,5 +196,6 @@ test.describe('Timesheets PoC', () => {
     await expect(page.getByText('GraphQL Worker / PRJ-GQL: Approve 完了')).toBeVisible();
     await page.getByRole('button', { name: 'All' }).click();
     await expect(page.locator('table tbody tr', { hasText: 'GraphQL Worker' }).first()).toContainText('Approved');
+    await expect(page.getByTestId('timesheets-summary-filters')).toContainText('すべて');
   });
 });


### PR DESCRIPTION
## 概要
- Timesheets 画面のヘッダーに表示件数・API取得件数・選択中フィルタ（ステータス/キーワード）を表示し、一覧状況を把握しやすくしました
- 検索/フィルタ更新時の GraphQL/REST/Mock それぞれで  のテレメトリを発火し、件数や戦略を収集できるようにしました
- E2E テストで新しいサマリ表示を検証し、キーワード検索・承認オペレーション後の表示内容を確認するようにしました

## テスト
- npm run lint
- npm run test:e2e -- timesheets
