### PR TITLE
feat: pm-service GraphQLフィルタ拡張

### DIFF
--- a/poc/event-backbone/local/services/pm-service/__tests__/graphql.test.js
+++ b/poc/event-backbone/local/services/pm-service/__tests__/graphql.test.js
@@ -57,6 +57,29 @@ describe('GraphQL schema', () => {
     });
   });
 
+  test('filters projects by manager and tag', async () => {
+    const response = await graphql(
+      `
+        query Projects($manager: String, $tag: String) {
+          projects(manager: $manager, tag: $tag) {
+            id
+            manager
+            tags
+          }
+        }
+      `,
+      { manager: '山田', tag: 'dx' },
+    ).expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+    const returned = response.body.data.projects;
+    expect(returned.length).toBeGreaterThan(0);
+    returned.forEach((project) => {
+      expect((project.manager || '').includes('山田')).toBeTruthy();
+      expect(project.tags).toContain('DX');
+    });
+  });
+
   test('creates and transitions project via GraphQL', async () => {
     const createRes = await graphql(
       `
@@ -154,6 +177,29 @@ describe('GraphQL schema', () => {
     rows.forEach((row) => {
       const haystack = `${row.projectCode} ${row.userName}`.toLowerCase();
       expect(haystack).toContain(keyword.toLowerCase());
+    });
+  });
+
+  test('filters timesheets by user and project code', async () => {
+    const response = await graphql(
+      `
+        query Timesheets($userName: String, $projectCode: String) {
+          timesheets(userName: $userName, projectCode: $projectCode) {
+            id
+            userName
+            projectCode
+          }
+        }
+      `,
+      { userName: '佐藤', projectCode: 'dx-2025-01' },
+    ).expect(200);
+
+    expect(response.body.errors).toBeUndefined();
+    const rows = response.body.data.timesheets;
+    expect(rows.length).toBeGreaterThan(0);
+    rows.forEach((row) => {
+      expect(row.projectCode.toLowerCase()).toBe('dx-2025-01');
+      expect(row.userName).toContain('佐藤');
     });
   });
 

--- a/poc/event-backbone/local/services/pm-service/graphql-schema.js
+++ b/poc/event-backbone/local/services/pm-service/graphql-schema.js
@@ -282,13 +282,34 @@ export function createGraphQLSchema({
         args: {
           status: { type: GraphQLString },
           keyword: { type: GraphQLString },
+          manager: { type: GraphQLString },
+          health: { type: GraphQLString },
+          tag: { type: GraphQLString },
         },
         resolve: (_root, args) => {
           const keyword = typeof args?.keyword === 'string' ? args.keyword.trim().toLowerCase() : '';
           const status = typeof args?.status === 'string' ? args.status.trim().toLowerCase() : '';
+          const manager = typeof args?.manager === 'string' ? args.manager.trim().toLowerCase() : '';
+          const health = typeof args?.health === 'string' ? args.health.trim().toLowerCase() : '';
+          const tag = typeof args?.tag === 'string' ? args.tag.trim().toLowerCase() : '';
           const filteredProjects = projects.filter((project) => {
             const statusMatch = !status || status === 'all' || project.status === status;
             if (!statusMatch) return false;
+            if (health && project.health !== health) return false;
+            if (manager) {
+              const managerName = (project.manager ?? '').toLowerCase();
+              if (!managerName.includes(manager)) {
+                return false;
+              }
+            }
+            if (tag) {
+              const tagList = Array.isArray(project.tags)
+                ? project.tags.filter(Boolean).map((value) => value.toLowerCase())
+                : [];
+              if (!tagList.includes(tag)) {
+                return false;
+              }
+            }
             if (!keyword) return true;
             const haystack = `${project.name} ${project.code ?? ''} ${project.clientName ?? ''}`.toLowerCase();
             return haystack.includes(keyword);
@@ -302,17 +323,33 @@ export function createGraphQLSchema({
           status: { type: GraphQLString },
           projectId: { type: GraphQLString },
           keyword: { type: GraphQLString },
+          userName: { type: GraphQLString },
+          projectCode: { type: GraphQLString },
         },
         resolve: (_root, args) => {
           const status = typeof args?.status === 'string' ? args.status.trim().toLowerCase() : '';
           const projectId = typeof args?.projectId === 'string' ? args.projectId.trim() : '';
           const keyword = typeof args?.keyword === 'string' ? args.keyword.trim().toLowerCase() : '';
+          const userName = typeof args?.userName === 'string' ? args.userName.trim().toLowerCase() : '';
+          const projectCodeArg = typeof args?.projectCode === 'string' ? args.projectCode.trim().toLowerCase() : '';
           const filteredTimesheets = timesheets.filter((sheet) => {
             const statusMatch = !status || status === 'all' || sheet.approvalStatus === status;
             if (!statusMatch) return false;
             const projectMatch =
               !projectId || sheet.projectId === projectId || sheet.projectCode === projectId;
             if (!projectMatch) return false;
+            if (userName) {
+              const name = (sheet.userName ?? '').toLowerCase();
+              if (!name.includes(userName)) {
+                return false;
+              }
+            }
+            if (projectCodeArg) {
+              const codeLower = (sheet.projectCode ?? '').toLowerCase();
+              if (codeLower !== projectCodeArg) {
+                return false;
+              }
+            }
             if (!keyword) return true;
             const haystack = [
               sheet.projectCode,

--- a/ui-poc/src/features/timesheets/TimesheetsClient.tsx
+++ b/ui-poc/src/features/timesheets/TimesheetsClient.tsx
@@ -93,6 +93,18 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
 
   const source: QuerySource = meta.fallback ? "mock" : "api";
 
+  const statusLabel = useMemo(() => {
+    if (filter === "all") {
+      return "すべて";
+    }
+    return STATUS_LABEL[filter];
+  }, [filter]);
+
+  const keywordSummary = appliedKeyword.trim().length > 0 ? `"${appliedKeyword}"` : "指定なし";
+
+  const apiReturned = meta.returned ?? timesheets.length;
+  const apiTotal = meta.total ?? timesheets.length;
+
   const filtered = useMemo(() => {
     const keyword = appliedKeyword.trim().toLowerCase();
     return timesheets.filter((entry) => {
@@ -668,10 +680,14 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
       </form>
 
       <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
-        <span>
-          表示件数: {filtered.length.toLocaleString()} / {meta.total.toLocaleString()} 件
+        <span data-testid="timesheets-summary-count">
+          表示件数: {filtered.length.toLocaleString()} 件 ({apiReturned.toLocaleString()} / {apiTotal.toLocaleString()} 件)
+        </span>
+        <span data-testid="timesheets-summary-filters">
+          フィルタ: {statusLabel} / キーワード: {keywordSummary}
         </span>
         <span>取得時刻: {formatDateTime(meta.fetchedAt)}</span>
+        {meta.status ? <span>APIステータス: {meta.status}</span> : null}
         <span
           className={`rounded-full px-2 py-1 font-medium ${
             source === "api" ? "bg-emerald-500/20 text-emerald-200" : "bg-amber-500/20 text-amber-200"

--- a/ui-poc/tests/e2e/api-live.spec.ts
+++ b/ui-poc/tests/e2e/api-live.spec.ts
@@ -20,6 +20,17 @@ test.describe('API Live Integration', () => {
     await expect(liveBadge).toBeVisible();
   });
 
+  test('timesheets summary reflects filter changes', async ({ page }) => {
+    await page.goto('/timesheets');
+    await expect(page.getByText('API live')).toBeVisible();
+    await expect(page.getByTestId('timesheets-summary-count')).toContainText('表示件数');
+    await expect(page.getByTestId('timesheets-summary-filters')).toContainText('指定なし');
+
+    await page.getByTestId('timesheets-search-input').fill('DX');
+    await page.getByRole('button', { name: '検索' }).click();
+    await expect(page.getByTestId('timesheets-summary-filters')).toContainText('"DX"');
+  });
+
   test('compliance download provides signed url', async ({ page, request }) => {
     await page.goto('/compliance');
     const liveBadge = page.getByText('API live');


### PR DESCRIPTION
## 概要
- GraphQL  に manager/health/tag 引数、 に userName/projectCode 引数を追加し、PoC API で複合条件検索ができるようにしました
- Jest の GraphQL テストを拡張し、新しいフィルタ条件で Seed データが絞り込めることを検証しています
- Playwright の API live シナリオにタイムシートサマリの検証を追加し、実 API でフィルタ反映が視認できるようにしました

## テスト
- (cd poc/event-backbone/local/services/pm-service && npm test)
- npm run test:e2e -- timesheets
