### PR TITLE
test: relax home navigation URL expectation

### DIFF
--- a/ui-poc/tests/e2e/home.spec.ts
+++ b/ui-poc/tests/e2e/home.spec.ts
@@ -10,6 +10,6 @@ test.describe('Home Navigation', () => {
     await expect(page.getByText('ITDO ERP3 UI PoC')).toBeVisible();
 
     await page.getByRole('link', { name: 'Timesheets' }).click();
-    await expect(page).toHaveURL(/\/timesheets$/);
+    await expect(page).toHaveURL(/\/timesheets(\?.*)?$/);
   });
 });


### PR DESCRIPTION
## 概要\n- Timesheetsページ遷移時にデフォルトフィルタがクエリに反映される挙動へ合わせ、HomeナビゲーションのE2E期待値を更新\n- Homeスイートの失敗要因だったURL末尾一致のみの検証を、クエリ文字列を許容する正規表現に変更\n\n## テスト\n- npm run lint\n- npm run test:e2e -- home\n- npm run test:e2e -- telemetry\n\n## 関連\n- refs #127\n