### PR TITLE
docs: document podman detach workflow

### DIFF
--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -1,0 +1,61 @@
+# Podman UI PoC フロー手順
+
+このドキュメントは、Podman スタック上で UI PoC を操作する際の標準手順をまとめたものです。環境準備から代表的な業務フロー、終了方法までを記載し、人による検証結果をそのまま本実装の改善に反映できるようにします。
+
+## 前提
+
+- `podman` / `podman-compose` が導入済みであること
+- `ui-poc` ディレクトリで `npm install` 済みであること
+- Playwright など E2E テストを並行して実行しないこと（ポート競合を避けるため）
+
+## 起動手順
+
+1. 端末 A でバックエンド + UI を起動（Detach 推奨）
+   ```bash
+   PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh --detach
+   ```
+   - `--detach` を付けるとスクリプトが即時終了し、他のターミナルで作業を継続できます。
+   - ログ: `ui-poc/.next/dev.log`
+   - コンテナ確認: `cd poc/event-backbone/local && podman-compose -f podman-compose.yml ps`
+
+2. 動作確認
+   ```bash
+   curl -fsS http://localhost:3101/health
+   curl -fsS http://localhost:4100 | head -n5
+   ```
+   200 が返ればスタックは正常に稼働しています。
+
+## 代表業務フロー
+
+| ステップ | 画面 | 操作 | 成功基準 | 備考 |
+| -------- | ---- | ---- | -------- | ---- |
+| 1 | Home | `http://localhost:4100/` を開く | Metrics パネルのカウントが表示される | `Podman Metrics Snapshot` を確認 |
+| 2 | Projects | ナビゲーションから `Projects` を選択 | `API live` バッジが付き、カードが 4 件表示される | GraphQL エラーが出た場合は REST フォールバックを許容 |
+| 3 | Timesheets | `Timesheets` を選択し、ステータス/メンバー/プロジェクトフィルタを操作 | フィルタサマリに入力値が反映され、テーブルが更新される | 承認/差戻しボタンでトースト表示を確認 |
+| 4 | Compliance | `Compliance` を選択し、検索→ソート→ページング | リスト数が更新され、詳細パネルが表示される | Podman 停止時はモックバナーが表示される |
+| 5 | Telemetry | `Telemetry` を選択し、フィルタを設定 → `適用` | イベントテーブルにフィルタ結果が表示され、URLクエリが更新される | 自動更新のカウントダウンが進んでいること |
+| 6 | Metrics / Events | 必要に応じて `scripts/show_telemetry.js` や `/metrics/summary` を確認 | 最新イベント・メトリクスの値が更新されている | RabbitMQ/Redis を使ったイベントフローを確認する場合は `local_consumer` ログを参照 |
+
+検証結果は Issue コメントに箇条書きで残し、UI/UX 上の気付きや不具合を新規 Issue に切り出してください。
+
+## 停止手順
+
+```bash
+# Podman スタックを停止
+cd poc/event-backbone/local
+podman-compose -f podman-compose.yml down
+
+# Next.js Dev Server を停止（Detach モードの場合のみ）
+pkill -f "next dev --hostname 0.0.0.0 --port"
+```
+
+`podman-compose down` は現在のネットワークとコンテナを全て削除します。次回起動時には `run_podman_ui_poc.sh --detach` を再実行してください。
+
+## トラブルシューティング
+
+- **UI ポートが競合する**: `UI_PORT` を変更するか、既存の Next.js プロセスを停止します。
+- **pm-service が 60 秒以内に起動しない**: `podman-compose logs local_pm-service_1` でエラー内容を確認してください。MinIO 有効時は初回に少し時間が掛かります。
+- **GraphQL エラーで REST フォールバックになる**: 現状の PoC 仕様上許容されます。フォールバック後も UI 操作に支障がないか確認してください。
+- **イベントが流れない**: `podman logs local_producer_1` / `local_consumer_1` を確認し、RabbitMQ の接続エラーが解消されているかチェックします。
+
+以上の手順をベースに、人手によるワークフロー検証とフィードバック収集を継続してください。

--- a/scripts/run_podman_ui_poc.sh
+++ b/scripts/run_podman_ui_poc.sh
@@ -241,7 +241,7 @@ if [ "${UI_HEADLESS}" = 'true' ]; then
     printf '\n[ui] Detach mode enabled. Stack will continue running in the background.\n'
     printf '     Stop it manually with:\n'
     printf '       (cd %s && podman-compose -f %s down)\n' "${PROJECT_DIR}" "${COMPOSE_FILE}"
-    printf '       kill %s  # Next.js dev server\n' "${NEXT_DEV_PID}"
+    printf '       pkill -f "next dev --hostname 0.0.0.0 --port %s"\n' "${UI_PORT_VALUE}"
     trap - EXIT
     exit 0
   fi

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -41,6 +41,20 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
 > Live テスト (`--run-tests` / `--tests-only`) を利用する場合は、Playwright の実行前に PoC API を既定ポート（3001）へ一旦リダイレクトするため、環境変数 `FORCE_PM_PORT` で強制ポートを指定できます。Podman スタックを独自ポートで常用している場合は、テスト専用に `FORCE_PM_PORT=3001` を維持するか、Playwright 側の `PM_PORT` を合わせて上書きしてください。
 ```
 
+#### Detach モード
+
+同じターミナルで追加作業を継続したい場合は `--detach` を付与すると Podman スタックと Next.js Dev Server をバックグラウンドで起動し、スクリプトは即時終了します。
+
+```bash
+PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh --detach
+
+# 停止する際は明示的に以下を実行
+(cd poc/event-backbone/local && podman-compose -f podman-compose.yml down)
+pkill -f "next dev --hostname 0.0.0.0 --port 4100"
+```
+
+ログは `.next/dev.log` に記録されます。Detach を有効にすると自動クリーンアップが行われないため、検証終了後は手動でスタックを停止してください。
+
 ## ディレクトリ構成（抜粋）
 
 - `src/app` … App Router を用いた画面コンポーネント
@@ -54,6 +68,8 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh
 - 実データ/モックデータの表示やUIパターンの実装
 - Podman スタックとの結合テスト強化
 - UX検討のための操作シナリオドキュメント整備
+
+補助資料: [`docs/podman-ui-workflow.md`](../docs/podman-ui-workflow.md) に Podman スタックの起動・操作・停止フローと代表的な検証手順をまとめています。
 
 > ⚠️ このプロジェクトは PoC 目的のため、本番品質を前提としていません。
 

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -50,7 +50,7 @@ PM_PORT=3101 UI_PORT=4100 scripts/run_podman_ui_poc.sh --detach
 
 # 停止する際は明示的に以下を実行
 (cd poc/event-backbone/local && podman-compose -f podman-compose.yml down)
-pkill -f "next dev --hostname 0.0.0.0 --port 4100"
+pkill -f "next dev --hostname 0.0.0.0 --port $UI_PORT"
 ```
 
 ログは `.next/dev.log` に記録されます。Detach を有効にすると自動クリーンアップが行われないため、検証終了後は手動でスタックを停止してください。


### PR DESCRIPTION
## 概要
- [podman] Starting backend PoC stack via podman-compose
[podman] USE_MINIO=false
STEP 1/5: FROM node:20-alpine
STEP 1/5: FROM node:20-alpine
STEP 1/7: FROM node:20-alpine
STEP 2/5: WORKDIR /app
STEP 2/7: WORKDIR /app
STEP 2/5: WORKDIR /app
--> Using cache bb31f9bbf702f266a450770da8ccbd2a983e17521465c5c974f880045cc8a7d8
--> bb31f9bbf702
--> Using cache bb31f9bbf702f266a450770da8ccbd2a983e17521465c5c974f880045cc8a7d8
--> bb31f9bbf702
--> Using cache bb31f9bbf702f266a450770da8ccbd2a983e17521465c5c974f880045cc8a7d8
--> bb31f9bbf702
STEP 3/5: COPY index.js package.json package-lock.json* ./
STEP 3/5: COPY index.js package.json package-lock.json* ./
STEP 3/7: COPY package.json package-lock.json* ./
--> Using cache 74827d9506a72ee92975cc91d2b4a51441e3018f78118350d162d450af34bdce
--> 74827d9506a7
STEP 4/5: RUN npm ci --omit=dev || npm i --omit=dev
--> Using cache 139a657e3b38b754efd035699951fefca58361db1897c5db76742d0f8136791a
--> 139a657e3b38
STEP 4/5: RUN npm ci --omit=dev || npm i --omit=dev
--> Using cache 9283cd80082c4f34b877bc968b706b03050e83720bf514ba8caf302b53da70b4
--> 9283cd80082c
STEP 5/5: CMD ["node", "index.js"]
--> Using cache b1850e14d067764288f0719976ee72cd96b8b490f2b28a1c42a94191b4add590
--> b1850e14d067
--> Using cache 16c868c7fc8e0b764dcbbc901e29dc864bf9cdf06858ba75edf5df381d28a992
--> 16c868c7fc8e
STEP 4/7: RUN npm ci --omit=dev || npm i --omit=dev
STEP 5/5: CMD ["node", "index.js"]
--> Using cache 0c49008a324ff7dd6454a05d1041ee90be75469fd00f01513523fe89433981e0
--> 0c49008a324f
STEP 5/7: COPY index.js sample-data.js graphql-schema.js ./
--> Using cache ae65a6c835e5ed6430a62b38560a5b04fe16a57b2f4f63d3dac6652eef016a73
COMMIT local_consumer
--> Using cache 5ed6e87ae66c64a612e95cacfcd0c61bb95e63bf1f1a972561fed68d8b3f1092
COMMIT local_producer
--> ae65a6c835e5
Successfully tagged localhost/local_consumer:latest
ae65a6c835e5ed6430a62b38560a5b04fe16a57b2f4f63d3dac6652eef016a73
--> 5ed6e87ae66c
Successfully tagged localhost/local_producer:latest
5ed6e87ae66c64a612e95cacfcd0c61bb95e63bf1f1a972561fed68d8b3f1092
--> Using cache 84f401890d6cef85d9743dae1b34530f3516ec217dfcf8eeafc3cf7160924652
--> 84f401890d6c
STEP 6/7: EXPOSE 3001
--> Using cache e8647bc33fc2e79dab48a997547da9cf9f98fb527389d250ac1779f3feb3ef61
--> e8647bc33fc2
STEP 7/7: CMD ["node", "index.js"]
--> Using cache d7c88d006fd8faa3a326da3007709efa6894ae0cd1740fa4d6b15354fdd5225c
COMMIT local_pm-service
--> d7c88d006fd8
Successfully tagged localhost/local_pm-service:latest
d7c88d006fd8faa3a326da3007709efa6894ae0cd1740fa4d6b15354fdd5225c
local_producer_1
[health] Waiting for pm-service on http://localhost:3001
[health] Waiting for GraphQL endpoint on http://localhost:3001/graphql
[ui] Starting Next.js dev server on port 4000
      (API base: http://localhost:3001)

> ui-poc@0.1.0 dev
> next dev --hostname 0.0.0.0 --port 4000

[?25h

[cleanup] Stopping UI PoC stack... に  オプションを追加し、Podman スタックと Next.js Dev Server をバックグラウンドで起動できるようにした
- Detach 利用時の停止手順や代表的な検証フローをまとめた  を追加
- README に新オプションと手順書へのリンクを追記

## 動作確認
- scripts/run_podman_ui_poc.sh --detach
  - Podman コンテナと Next.js Dev Server が継続動作することを確認
- docs/podman-ui-workflow.md を参照し、代表フローの手順が最新であることを確認

## 関連
- refs #126
- refs #127
