### PR TITLE
docs: capture podman manual verification

### DIFF
--- a/docs/podman-manual-log-template.md
+++ b/docs/podman-manual-log-template.md
@@ -1,0 +1,14 @@
+# Podman 手動検証ログテンプレート
+
+| 項目 | 結果 | 備考 |
+| ---- | ---- | ---- |
+| 実行日時 | YYYY-MM-DD HH:MM | 例: 2025-10-07 08:00 JST |
+| PM_PORT / UI_PORT | 3103 / 4103 | `scripts/run_podman_ui_poc.sh --detach` の引数 |
+| `scripts/podman_status.sh` | ✅ / ❌ | 成功時は `ok` 表示をメモ |
+| Projects 一覧件数 | 4 | `curl http://localhost:${PM_PORT}/api/v1/projects` |
+| Timesheets submitted 件数 | 2 | `curl http://localhost:${PM_PORT}/api/v1/timesheets?status=submitted` |
+| Compliance 検索件数 | 3 | `curl http://localhost:${PM_PORT}/api/v1/compliance/invoices?limit=5` |
+| Telemetry 取得 | 0 | `TELEMETRY_BASE=http://localhost:${PM_PORT} node scripts/show_telemetry.js` |
+| フィードバック | - | UI/UX 改善や不具合を箇条書き |
+
+`docs/podman-ui-workflow.md` の手順に従い実施し、必要に応じて Issue へコメントや新規Issue作成を行ってください。

--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -51,6 +51,21 @@ pkill -f "next dev --hostname 0.0.0.0 --port"
 
 `podman-compose down` は現在のネットワークとコンテナを全て削除します。次回起動時には `run_podman_ui_poc.sh --detach` を再実行してください。
 
+
+## ログ記録とサンプル
+
+- 簡易ヘルスチェック: `PM_PORT=3103 UI_PORT=4103 scripts/podman_status.sh`
+- テンプレート: [`docs/podman-manual-log-template.md`](podman-manual-log-template.md)
+
+### 実施例 (2025-10-07 08:00 JST)
+| 項目 | 結果 | 備考 |
+| ---- | ---- | ---- |
+| `scripts/podman_status.sh` | ok | すべてのヘルスチェックが `ok` |
+| Projects 件数 | 4 | `curl http://localhost:3103/api/v1/projects` |
+| Timesheets submitted | 2 | `curl http://localhost:3103/api/v1/timesheets?status=submitted` |
+| Compliance (limit=5) | 3 | `curl http://localhost:3103/api/v1/compliance/invoices?limit=5` |
+| Telemetry | 0 | `TELEMETRY_BASE=http://localhost:3103 node scripts/show_telemetry.js` |
+
 ## トラブルシューティング
 
 - **UI ポートが競合する**: `UI_PORT` を変更するか、既存の Next.js プロセスを停止します。

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -55,6 +55,8 @@ pkill -f "next dev --hostname 0.0.0.0 --port $UI_PORT"
 
 ログは `.next/dev.log` に記録されます。Detach を有効にすると自動クリーンアップが行われないため、検証終了後は手動でスタックを停止してください。
 
+ヘルスチェックには `scripts/podman_status.sh` を利用できます。`PM_PORT` / `UI_PORT` を合わせて実行すると、コンテナ一覧と主要エンドポイントの状態をまとめて確認できます。
+
 ## ディレクトリ構成（抜粋）
 
 - `src/app` … App Router を用いた画面コンポーネント


### PR DESCRIPTION
## 概要\n- Podman UI PoC 手順書にログ記録例と 
== Podman containers ==
CONTAINER ID  IMAGE                                               COMMAND               CREATED         STATUS                    PORTS                                             NAMES
021479dead9d  docker.io/library/rabbitmq:3.12-management          rabbitmq-server       41 seconds ago  Up 31 seconds             0.0.0.0:5672->5672/tcp, 0.0.0.0:15672->15672/tcp  local_rabbitmq_1
86dfff48ec02  docker.io/library/redis:7-alpine                    redis-server          40 seconds ago  Up 30 seconds             0.0.0.0:6379->6379/tcp                            local_redis_1
b67e0a9a4058  docker.io/minio/minio:RELEASE.2024-08-17T01-24-54Z  server /data --co...  39 seconds ago  Up 29 seconds (healthy)   0.0.0.0:9000-9001->9000-9001/tcp                  local_minio_1
c952945d8db7  docker.io/grafana/loki:2.9.3                        -config.file=/etc...  38 seconds ago  Up 28 seconds             0.0.0.0:3100->3100/tcp                            local_loki_1
4d7898eff890  docker.io/grafana/promtail:2.9.3                    -config.file=/etc...  37 seconds ago  Up 27 seconds                                                               local_promtail_1
ff5e003026f9  docker.io/grafana/grafana:10.4.4                                          35 seconds ago  Up Less than a second     0.0.0.0:3000->3000/tcp                            local_grafana_1
634d0eb4875b  localhost/local_producer:latest                     node index.js         34 seconds ago  Exited (0) 8 seconds ago                                                    local_producer_1
fcb0d51a608a  localhost/local_consumer:latest                     node index.js         33 seconds ago  Up 23 seconds                                                               local_consumer_1
400edfe4c9da  localhost/local_pm-service:latest                   node index.js         31 seconds ago  Up 21 seconds             0.0.0.0:3001->3001/tcp                            local_pm-service_1

== Service health ==
http://localhost:3001/health                  : ok
http://localhost:3001/metrics/summary         : ok

== UI availability ==
http://localhost:4000                        : ok

== Processes ==
 974040 node /home/devuser/work/CodeX/ITDO_ERP3/ui-poc/node_modules/.bin/next dev --hostname 127.0.0.1 --port 4100
1427007 /usr/lib/podman/aardvark-dns --config /mnt/wslg/runtime-dir/containers/networks/aardvark-dns -p 53 run
1427027 /usr/bin/conmon --api-version 1 -c 63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6 -u 63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata/pidfile -n supabase-studio --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6
1427189 /usr/bin/conmon --api-version 1 -c 302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1 -u 302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata/pidfile -n supabase-kong --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1
1428386 /usr/bin/conmon --api-version 1 -c c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a -u c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata/pidfile -n supabase-imgproxy --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a
1428548 /usr/bin/conmon --api-version 1 -c 00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0 -u 00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata/pidfile -n supabase-edge-functions --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0
1428662 /usr/bin/conmon --api-version 1 -c 4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846 -u 4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata/pidfile -n supabase-db --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846
1428835 /usr/bin/conmon --api-version 1 -c 35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c -u 35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata/pidfile -n supabase-auth --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c
1428974 /usr/bin/conmon --api-version 1 -c 34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955 -u 34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata/pidfile -n supabase-rest --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955
1429149 /usr/bin/conmon --api-version 1 -c aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474 -u aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata/pidfile -n realtime-dev.supabase-realtime --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474
1429372 /usr/bin/conmon --api-version 1 -c f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180 -u f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata/pidfile -n supabase-meta --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180
1429632 /usr/bin/conmon --api-version 1 -c 125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36 -u 125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata/pidfile -n supabase-pooler --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36
1429994 /usr/bin/conmon --api-version 1 -c 2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930 -u 2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata/pidfile -n supabase-storage --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930
1432778 /usr/bin/conmon --api-version 1 -c e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4 -u e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata/pidfile -n backend-users --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4
1662357 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /tmp/podman-1000/3973cc9f3cd48eff300a4c4b49d3d931/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
1662358 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --cancellationPipeName /tmp/podman-1000/1faf5e71884143fc5ce95b29e0a4e39b/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
1945388 /home/devuser/.local/share/mise/installs/python/3.12.11/bin/python3.12 /home/devuser/.local/bin/podman-compose -f /home/devuser/work/CodeX/ITDO_ERP3/poc/event-backbone/local/podman-compose.yml up -d --build
2691402 bash scripts/run_podman_ui_poc.sh
2695860 sh -c next dev --hostname 0.0.0.0 --port 4000
2695862 node /home/devuser/work/CodeX/ITDO_ERP3/ui-poc/node_modules/.bin/next dev --hostname 0.0.0.0 --port 4000
3753635 /usr/bin/conmon --api-version 1 -c 021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46 -u 021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata/pidfile -n local_rabbitmq_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46
3754172 /usr/bin/conmon --api-version 1 -c 86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c -u 86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata/pidfile -n local_redis_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c
3754343 /usr/bin/conmon --api-version 1 -c b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282 -u b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata/pidfile -n local_minio_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282
3754817 /usr/bin/conmon --api-version 1 -c c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5 -u c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata/pidfile -n local_loki_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5
3755108 /usr/bin/conmon --api-version 1 -c 4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc -u 4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata/pidfile -n local_promtail_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc
3756808 /usr/bin/conmon --api-version 1 -c fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566 -u fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata/pidfile -n local_consumer_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566
3757384 /usr/bin/conmon --api-version 1 -c 400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507 -u 400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata/pidfile -n local_pm-service_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507
3764130 bash -lc gh pr create --head feature/podman-workflow-log --base main --title "docs: capture podman manual verification" --body "## 概要\n- Podman UI PoC 手順書にログ記録例と `scripts/podman_status.sh` の利用例を追記\n- 手動検証の記録テンプレート `docs/podman-manual-log-template.md` を追加\n- README にステータススクリプトの案内を補足\n\n## 関連\n- refs #126\n- refs #127\n"
3764137 bash scripts/podman_status.sh
3764234 /usr/bin/conmon --api-version 1 -c ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32 -u ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32/userdata/pidfile -n local_grafana_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32
3764298 /usr/bin/podman --root /home/devuser/.local/share/containers/storage --runroot /mnt/wslg/runtime-dir/containers --log-level warning --cgroup-manager cgroupfs --tmpdir /mnt/wslg/runtime-dir/libpod/tmp --network-config-dir  --network-backend netavark --volumepath /home/devuser/.local/share/containers/storage/volumes --db-backend sqlite --transient-store=false --runtime crun --storage-driver overlay --events-backend journald container cleanup ff5e003026f994749c943c2c9a09af85dc7d96488075169bbe80ef3dbd83eb32 の利用例を追記\n- 手動検証の記録テンプレート  を追加\n- README にステータススクリプトの案内を補足\n\n## 関連\n- refs #126\n- refs #127\n