### PR TITLE
chore: add telemetry sample sender

### DIFF
--- a/docs/podman-manual-log-template.md
+++ b/docs/podman-manual-log-template.md
@@ -9,6 +9,7 @@
 | Timesheets submitted 件数 | 2 | `curl http://localhost:${PM_PORT}/api/v1/timesheets?status=submitted` |
 | Compliance 検索件数 | 3 | `curl http://localhost:${PM_PORT}/api/v1/compliance/invoices?limit=5` |
 | Telemetry 取得 | 0 | `TELEMETRY_BASE=http://localhost:${PM_PORT} node scripts/show_telemetry.js` |
+| Telemetry 送信 | - | `PM_PORT=${PM_PORT} scripts/send_telemetry_sample.sh` などでイベント生成 |
 | フィードバック | - | UI/UX 改善や不具合を箇条書き |
 
 `docs/podman-ui-workflow.md` の手順に従い実施し、必要に応じて Issue へコメントや新規Issue作成を行ってください。

--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -56,6 +56,7 @@ pkill -f "next dev --hostname 0.0.0.0 --port"
 
 - 簡易ヘルスチェック: `PM_PORT=3103 UI_PORT=4103 scripts/podman_status.sh`
 - テンプレート: [`docs/podman-manual-log-template.md`](podman-manual-log-template.md)
+- Telemetryイベント送信: `PM_PORT=3103 TELEMETRY_BASE=http://localhost:3103 scripts/send_telemetry_sample.sh manual/ui-check event_info`
 
 ### 実施例 (2025-10-07 08:00 JST)
 | 項目 | 結果 | 備考 |

--- a/scripts/send_telemetry_sample.sh
+++ b/scripts/send_telemetry_sample.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT=${PM_PORT:-3001}
+BASE_URL=${TELEMETRY_BASE:-http://localhost:${PORT}}
+COMPONENT=${1:-manual/test}
+EVENT=${2:-log_sample}
+LEVEL=${3:-info}
+DETAIL=${4:-"Triggered via send_telemetry_sample.sh"}
+
+payload=$(cat <<JSON
+{
+  "component": "${COMPONENT}",
+  "event": "${EVENT}",
+  "level": "${LEVEL}",
+  "detail": {
+    "message": "${DETAIL}",
+    "timestamp": "$(date -Iseconds)"
+  }
+}
+JSON
+)
+
+curl -fsS -H 'Content-Type: application/json' \
+  -d "${payload}" \
+  "${BASE_URL}/api/v1/telemetry/ui" >/dev/null
+
+echo "[telemetry] sent component='${COMPONENT}', event='${EVENT}' to ${BASE_URL}"

--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -56,6 +56,7 @@ pkill -f "next dev --hostname 0.0.0.0 --port $UI_PORT"
 ログは `.next/dev.log` に記録されます。Detach を有効にすると自動クリーンアップが行われないため、検証終了後は手動でスタックを停止してください。
 
 ヘルスチェックには `scripts/podman_status.sh` を利用できます。`PM_PORT` / `UI_PORT` を合わせて実行すると、コンテナ一覧と主要エンドポイントの状態をまとめて確認できます。
+- Telemetryイベント送信補助: `scripts/send_telemetry_sample.sh` (例: `PM_PORT=3103 scripts/send_telemetry_sample.sh manual/ui-check event_info`)
 
 ## ディレクトリ構成（抜粋）
 


### PR DESCRIPTION
## 概要\n- Telemetry エンドポイントへ簡単にイベントを送信できる [telemetry] sent component='manual/test', event='log_sample' to http://localhost:3001 を追加\n- Podman 手順書とログテンプレートにサンプル送信手順を追記\n- README に Telemetry 補助スクリプトを案内\n\n## テスト\n- scripts/send_telemetry_sample.sh manual/test event_info\n\n## 関連\n- refs #126\n- refs #127\n