### PR TITLE
feat: Podmanホストフォールバックを自動化

### DIFF
--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -25,6 +25,9 @@ FORCE_PM_PORT=3001 USE_MINIO=true PM_PORT=3101 UI_PORT=4100 UI_HEADLESS=true scr
 - `SKIP_GRAPHQL_PREFLIGHT=true` を指定すると、GraphQL ウォームアップをスキップして素早くテストに入れます（起動直後の 400 応答が気になる場合は `false` のままにしてください）。
 - `E2E_REQUIRE_MINIO=true` を併用すると、Playwright が MinIO 署名 URL の有無を検証します。
 
+- `PODMAN_AUTO_HOST_FALLBACK=true` (既定値) の状態では、pm-service のヘルスチェックに失敗した際に `host.containers.internal` を経由した再起動を自動的に試行します。環境に応じて無効化したい場合は `PODMAN_AUTO_HOST_FALLBACK=false` を指定してください。
+- フォールバックで利用するホスト名を変更したい場合は `HOST_INTERNAL_ADDR` を上書きできます (既定: `host.containers.internal`)。
+
 ## 3. 個別の E2E テスト
 ```bash
 cd ui-poc

--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -67,12 +67,12 @@ pkill -f "next dev --hostname 0.0.0.0 --port"
 | Projects 件数 | 4 | `curl http://localhost:3103/api/v1/projects` |
 | Timesheets submitted | 2 | `curl http://localhost:3103/api/v1/timesheets?status=submitted` |
 | Compliance (limit=5) | 3 | `curl http://localhost:3103/api/v1/compliance/invoices?limit=5` |
-| Telemetry | ≥5 | `TELEMETRY_BASE=http://localhost:3103 node scripts/show_telemetry.js`（既定でサンプルイベントが投入済み） |
+| Telemetry | >=5 | `TELEMETRY_BASE=http://localhost:3103 node scripts/show_telemetry.js`（既定でサンプルイベントが投入済み） |
 
 ## トラブルシューティング
 
 - **UI ポートが競合する**: `UI_PORT` を変更するか、既存の Next.js プロセスを停止します。
-- **pm-service が 60 秒以内に起動しない**: `podman-compose logs local_pm-service_1` でエラー内容を確認してください。MinIO 有効時は初回に少し時間が掛かります。
+- **pm-service が 60 秒以内に起動しない**: `scripts/run_podman_ui_poc.sh` 使用時は自動で `host.containers.internal` フォールバックを試行します。ログ (`podman-compose logs local_pm-service_1`) を確認し、それでも解決しない場合は `PODMAN_AUTO_HOST_FALLBACK=false` で明示的に無効化した上で手動で再起動してください。MinIO 有効時は初回に時間が掛かる場合があります。
 - **GraphQL エラーで REST フォールバックになる**: 現状の PoC 仕様上許容されます。フォールバック後も UI 操作に支障がないか確認してください。
 - **イベントが流れない**: `podman logs local_producer_1` / `local_consumer_1` を確認し、RabbitMQ の接続エラーが解消されているかチェックします。
 

--- a/scripts/run_podman_ui_poc.sh
+++ b/scripts/run_podman_ui_poc.sh
@@ -16,6 +16,11 @@ FORCE_PM=${FORCE_PM_PORT:-3001}
 USE_BUILD="${PODMAN_BUILD:-true}"
 SKIP_GRAPHQL_PREFLIGHT="${SKIP_GRAPHQL_PREFLIGHT:-false}"
 DETACH=false
+PODMAN_AUTO_HOST_FALLBACK="${PODMAN_AUTO_HOST_FALLBACK:-true}"
+HOST_INTERNAL_ADDR="${HOST_INTERNAL_ADDR:-host.containers.internal}"
+RABBITMQ_HOST_PORT="${RABBITMQ_HOST_PORT:-5672}"
+REDIS_HOST_PORT="${REDIS_HOST_PORT:-6379}"
+MINIO_HOST_PORT="${MINIO_HOST_PORT:-${MINIO_PORT:-9000}}"
 
 usage() {
   cat <<USAGE
@@ -33,6 +38,7 @@ Options:
 Environment variables:
   PM_PORT, UI_PORT, PM_CONTAINER_PORT, UI_HEADLESS, USE_MINIO, PODMAN_BUILD,
   FORCE_PM_PORT (default 3001, Playwright live testsの強制ポート)
+  PODMAN_AUTO_HOST_FALLBACK (default true), HOST_INTERNAL_ADDR (default host.containers.internal)
 USAGE
 }
 
@@ -138,6 +144,59 @@ wait_for_graphql() {
   return 1
 }
 
+wait_for_pm_service() {
+  local port="$1"
+  local attempts=${PM_HEALTH_ATTEMPTS:-60}
+  echo "[health] Waiting for pm-service on http://localhost:${port}"
+  for ((i = 0; i < attempts; i++)); do
+    if curl -fsS "http://localhost:${port}/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# Switch service endpoints to host.containers.internal and restart the stack.
+enable_host_internal_fallback() {
+  local host="${HOST_INTERNAL_ADDR}"
+  echo "[podman] Enabling host.containers.internal fallback (${host})"
+  export AMQP_URL="amqp://guest:guest@${host}:${RABBITMQ_HOST_PORT}"
+  export REDIS_URL="redis://${host}:${REDIS_HOST_PORT}"
+  export MINIO_ENDPOINT="${host}"
+  export MINIO_PUBLIC_ENDPOINT="${MINIO_PUBLIC_ENDPOINT:-${host}}"
+  export MINIO_PUBLIC_PORT="${MINIO_PUBLIC_PORT:-${MINIO_HOST_PORT}}"
+  export PODMAN_HOST_FALLBACK_ACTIVE=true
+}
+
+should_attempt_host_fallback() {
+  [[ ${PODMAN_AUTO_HOST_FALLBACK,,} == "true" && ${fallback_attempted} == false ]]
+}
+
+perform_host_fallback() {
+  local reason="$1"
+  echo "[health] ${reason}; retrying with host.containers.internal fallback"
+  (cd "${PROJECT_DIR}" && podman-compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1) || true
+  enable_host_internal_fallback
+  fallback_attempted=true
+  launch_stack
+}
+
+launch_stack() {
+  echo "[podman] Starting backend PoC stack via podman-compose"
+  echo "[podman] USE_MINIO=${USE_MINIO_FLAG}"
+  local args=(-f "${COMPOSE_FILE}" up -d)
+  case "${USE_BUILD,,}" in
+    false|no|0)
+      echo "[podman] Skipping image build step (PODMAN_BUILD=${USE_BUILD})"
+      ;;
+    *)
+      args+=(--build)
+      ;;
+  esac
+  (cd "${PROJECT_DIR}" && podman-compose "${args[@]}")
+}
+
 # Export variables for podman-compose so that host/container port values are respected.
 export PM_PORT="${PM_HOST_PORT}"
 export PM_CONTAINER_PORT
@@ -155,38 +214,33 @@ cleanup() {
 
 trap cleanup EXIT
 
-cd "${PROJECT_DIR}"
+fallback_attempted=false
 
-echo "[podman] Starting backend PoC stack via podman-compose"
-echo "[podman] USE_MINIO=${USE_MINIO_FLAG}"
-compose_args=(-f "${COMPOSE_FILE}" up -d)
-case "${USE_BUILD,,}" in
-  false|no|0)
-    echo "[podman] Skipping image build step (PODMAN_BUILD=${USE_BUILD})"
-    ;;
-  *)
-    compose_args+=(--build)
-    ;;
-esac
-podman-compose "${compose_args[@]}"
+launch_stack
 
-echo "[health] Waiting for pm-service on http://localhost:${PM_HOST_PORT}"
-pm_service_up=false
-for _ in {1..60}; do
-  if curl -fsS "http://localhost:${PM_HOST_PORT}/health" >/dev/null 2>&1; then
-    pm_service_up=true
-    break
+if ! wait_for_pm_service "$PM_HOST_PORT"; then
+  if should_attempt_host_fallback; then
+    perform_host_fallback "pm-service did not become healthy"
+    if ! wait_for_pm_service "$PM_HOST_PORT"; then
+      echo "[health] ERROR: pm-service did not become available even after host fallback." >&2
+      exit 2
+    fi
+  else
+    echo "[health] ERROR: pm-service did not become available after 60 seconds. Exiting." >&2
+    exit 2
   fi
-  sleep 1
-done
-
-if [ "$pm_service_up" = false ]; then
-  echo "[health] ERROR: pm-service did not become available after 60 seconds. Exiting." >&2
-  exit 2
 fi
 
 if ! wait_for_graphql "$PM_HOST_PORT"; then
-  exit 5
+  if should_attempt_host_fallback; then
+    perform_host_fallback "GraphQL preflight failed"
+    if ! wait_for_pm_service "$PM_HOST_PORT" || ! wait_for_graphql "$PM_HOST_PORT"; then
+      echo "[health] ERROR: pm-service/GraphQL not ready after host fallback." >&2
+      exit 5
+    fi
+  else
+    exit 5
+  fi
 fi
 
 if [ "$RUN_TESTS" = true ]; then


### PR DESCRIPTION
## 概要
- `scripts/run_podman_ui_poc.sh` で pm-service のヘルスチェック失敗時に `host.containers.internal` へ自動フォールバックする処理を追加
- `PODMAN_AUTO_HOST_FALLBACK` / `HOST_INTERNAL_ADDR` などの新しい環境変数でフォールバックを制御可能に
- ライブ検証関連ドキュメントにフォールバックの挙動と運用手順を追記

## テスト
- `bash -n scripts/run_podman_ui_poc.sh`
- `scripts/run_podman_ui_poc.sh --help`

## 関連Issue
- refs #127
