### PR TITLE
Playwrightライブテストにテレメトリ初期シード検証を追加

### DIFF
--- a/ui-poc/tests/e2e/api-live.spec.ts
+++ b/ui-poc/tests/e2e/api-live.spec.ts
@@ -150,6 +150,14 @@ test.describe('API Live Integration', () => {
   });
 
   test('telemetry page displays latest events', async ({ page, request }) => {
+    const seedResponse = await request.get(`${API_BASE}/api/v1/telemetry/ui`);
+    expect(seedResponse.ok()).toBeTruthy();
+    const seedPayload = await seedResponse.json();
+    expect(seedPayload.total).toBeGreaterThanOrEqual(5);
+    expect(Array.isArray(seedPayload.items)).toBeTruthy();
+    const hasSeededMarker = seedPayload.items?.some((item: { detail?: { seeded?: boolean } }) => item?.detail?.seeded === true);
+    expect(hasSeededMarker).toBeTruthy();
+
     const eventName = `e2e-telemetry-${Date.now()}`;
     const response = await request.post(`${API_BASE}/api/v1/telemetry/ui`, {
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## 概要
- APIライブE2Eシナリオでtelemetryシードイベントの存在を検証
- シードイベントが投入されていることを事前確認してからUIに遷移

## テスト
- UI_PORT=4104 PM_PORT=3103 NEXT_PUBLIC_API_BASE=http://localhost:3103 POC_API_BASE=http://localhost:3103 npm run test:e2e:live