### PR TITLE
Podmanステータス確認にTelemetryシード検証を追加

### DIFF
--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -38,6 +38,8 @@
 
 > 💡 テレメトリ PoC では、pm-service 起動時にサンプルイベントが自動投入されます。実検証用に空の状態で開始したい場合は `TELEMETRY_SEED_DISABLE=true` を環境変数として渡してください。
 
+`scripts/podman_status.sh` を実行すると `Telemetry seed verification` セクションでシードイベント件数が自動判定されます。閾値を変更する場合は `TELEMETRY_MIN_SEEDED` 環境変数で上書きしてください。
+
 検証結果は Issue コメントに箇条書きで残し、UI/UX 上の気付きや不具合を新規 Issue に切り出してください。
 
 ## 停止手順
@@ -56,7 +58,7 @@ pkill -f "next dev --hostname 0.0.0.0 --port"
 
 ## ログ記録とサンプル
 
-- 簡易ヘルスチェック: `PM_PORT=3103 UI_PORT=4103 scripts/podman_status.sh`
+- 簡易ヘルスチェック: `PM_PORT=3103 UI_PORT=4103 scripts/podman_status.sh` （Telemetry seed verification で seeded 件数を自動チェック）
 - テンプレート: [`docs/podman-manual-log-template.md`](podman-manual-log-template.md)
 - Telemetryイベント送信（追加が必要な場合）: `PM_PORT=3103 TELEMETRY_BASE=http://localhost:3103 scripts/send_telemetry_sample.sh manual/ui-check event_info` (curl のレスポンスは自動でログに記録されますが、エラーとなった場合は標準エラー出力にメッセージが表示されます)
 

--- a/scripts/podman_status.sh
+++ b/scripts/podman_status.sh
@@ -31,6 +31,70 @@ for endpoint in \
   sleep 0.1
  done
 
+print_section "Telemetry seed verification"
+TELEMETRY_ENDPOINT="${TELEMETRY_ENDPOINT:-http://localhost:${PM_HOST_PORT}/api/v1/telemetry/ui?limit=50}"
+TELEMETRY_MIN_SEEDED=${TELEMETRY_MIN_SEEDED:-5}
+printf "%-45s : " "${TELEMETRY_ENDPOINT}"
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "skipped (python3 not available)"
+elif ! response=$(curl -fsS "${TELEMETRY_ENDPOINT}" 2>/dev/null); then
+  echo "error (failed to fetch telemetry payload)"
+else
+  export TELEMETRY_PAYLOAD="${response}"
+  export TELEMETRY_MIN_SEEDED
+  set +e
+  python_output=$(python3 <<'PY2'
+import json
+import os
+import sys
+
+payload_raw = os.environ.get("TELEMETRY_PAYLOAD", "")
+expected_raw = os.environ.get("TELEMETRY_MIN_SEEDED", "0")
+try:
+    expected = max(0, int(expected_raw))
+except Exception:
+    expected = 0
+
+try:
+    payload = json.loads(payload_raw)
+except Exception as exc:
+    print(f"JSON decode error: {exc}")
+    sys.exit(2)
+
+items = payload.get("items")
+if not isinstance(items, list):
+    print("payload missing items list")
+    sys.exit(2)
+
+seeded = sum(
+    1
+    for item in items
+    if isinstance(item, dict)
+    and isinstance(item.get("detail"), dict)
+    and item["detail"].get("seeded") is True
+)
+
+print(f"seeded events: {seeded} (expected >= {expected})")
+sys.exit(0 if seeded >= expected else 1)
+PY2
+  )
+  python_status=$?
+  unset TELEMETRY_PAYLOAD
+  set -e
+  clean_output=$(printf '%s' "${python_output}" | tr -d '\n')
+  if [ "${python_status}" -eq 0 ]; then
+    echo "ok - ${clean_output}"
+  else
+    if [ -n "${clean_output}" ]; then
+      echo "error - ${clean_output}"
+    else
+      echo "error - telemetry seed verification failed"
+    fi
+  fi
+fi
+
+
+
 print_section "UI availability"
 UI_PORT_VALUE=${UI_PORT:-4000}
 printf "http://localhost:%s                        : " "${UI_PORT_VALUE}"


### PR DESCRIPTION
## 概要
- 
== Podman containers ==
CONTAINER ID  IMAGE                                               COMMAND               CREATED        STATUS                    PORTS                                             NAMES
db2160cc7577  docker.io/library/rabbitmq:3.12-management          rabbitmq-server       8 minutes ago  Up 8 minutes              0.0.0.0:5672->5672/tcp, 0.0.0.0:15672->15672/tcp  local_rabbitmq_1
39fb197491ed  docker.io/library/redis:7-alpine                    redis-server          8 minutes ago  Up 8 minutes              0.0.0.0:6379->6379/tcp                            local_redis_1
1ec5629e6f32  docker.io/minio/minio:RELEASE.2024-08-17T01-24-54Z  server /data --co...  8 minutes ago  Up 8 minutes (healthy)    0.0.0.0:9000-9001->9000-9001/tcp                  local_minio_1
a45c35eadba4  docker.io/grafana/loki:2.9.3                        -config.file=/etc...  8 minutes ago  Up 8 minutes              0.0.0.0:3100->3100/tcp                            local_loki_1
405e945f31db  docker.io/grafana/promtail:2.9.3                    -config.file=/etc...  8 minutes ago  Up 8 minutes                                                                local_promtail_1
8538fb3abcee  docker.io/grafana/grafana:10.4.4                                          8 minutes ago  Up Less than a second     0.0.0.0:3000->3000/tcp                            local_grafana_1
ea703ad622f8  localhost/local_producer:latest                     node index.js         8 minutes ago  Exited (0) 8 minutes ago                                                    local_producer_1
8b931b645b22  localhost/local_consumer:latest                     node index.js         8 minutes ago  Up 8 minutes                                                                local_consumer_1
37000d0d2d70  localhost/local_pm-service:latest                   node index.js         8 minutes ago  Up 8 minutes              0.0.0.0:3103->3001/tcp                            local_pm-service_1

== Service health ==
http://localhost:3001/health                  : error
http://localhost:3001/metrics/summary         : error

== Telemetry seed verification ==
http://localhost:3001/api/v1/telemetry/ui?limit=50 : error (failed to fetch telemetry payload)

== UI availability ==
http://localhost:4000                        : error

== Processes ==
 380468 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /tmp/podman-1000/904d732daac82597760e6bf973ea3cb6/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
 380469 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --cancellationPipeName /tmp/podman-1000/bd2565ab24d9375cacaca413d782cbe9/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
 393376 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /tmp/podman-1000/219ef4ad1ccf135ce84e3a933fb11259/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
 393377 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --cancellationPipeName /tmp/podman-1000/e23b2ce6e11f0cfbf6805ce5d77e9979/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
1093597 /home/devuser/.local/share/mise/installs/python/3.12.11/bin/python3.12 /home/devuser/.local/bin/podman-compose -f /home/devuser/work/CodeX/ITDO_ERP3/poc/event-backbone/local/podman-compose.yml ps
1357041 /home/devuser/.local/share/mise/installs/python/3.12.11/bin/python3.12 /home/devuser/.local/bin/podman-compose -f /home/devuser/work/CodeX/ITDO_ERP3/poc/event-backbone/local/podman-compose.yml up -d
1427007 /usr/lib/podman/aardvark-dns --config /mnt/wslg/runtime-dir/containers/networks/aardvark-dns -p 53 run
1427027 /usr/bin/conmon --api-version 1 -c 63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6 -u 63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata/pidfile -n supabase-studio --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 63e585dd174304b12aab0bb8fcf1dbbdc6381287949521070230c61ada0124e6
1427189 /usr/bin/conmon --api-version 1 -c 302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1 -u 302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata/pidfile -n supabase-kong --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 302df95bd0091c527ce830ab385d776bf60ec21cd40bda92e3c68c1c193138f1
1428386 /usr/bin/conmon --api-version 1 -c c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a -u c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata/pidfile -n supabase-imgproxy --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg c075260e291f5bc0f77648a9641269ca9ffdabb63e360a20b9e9b238d07b642a
1428548 /usr/bin/conmon --api-version 1 -c 00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0 -u 00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata/pidfile -n supabase-edge-functions --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 00339f312ff37f7f3a2ad272b0b4d649a3eb2818ccd9a4d6cb90b91552f2ceb0
1428662 /usr/bin/conmon --api-version 1 -c 4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846 -u 4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata/pidfile -n supabase-db --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 4b2fcb810c4f64cee22101c0032e4daa8c1d139c789eea4f90a8206ce6a79846
1428835 /usr/bin/conmon --api-version 1 -c 35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c -u 35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata/pidfile -n supabase-auth --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 35f1d7cb70c6557678d12bbfe23c7700160cb7c6632f9490ede8ac23e91c403c
1428974 /usr/bin/conmon --api-version 1 -c 34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955 -u 34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata/pidfile -n supabase-rest --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 34a1597521a061b7bfbb4497398d91828971ab53d9f94093ea574c9ee4776955
1429149 /usr/bin/conmon --api-version 1 -c aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474 -u aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata/pidfile -n realtime-dev.supabase-realtime --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg aa0bea07a29c8907a64347e12c73860151c06bcdfe236531aa895bdc20f8a474
1429372 /usr/bin/conmon --api-version 1 -c f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180 -u f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata/pidfile -n supabase-meta --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg f362f1fba553972e9810f1330cec66a2e85c64209757a7ecdf66dbda79f37180
1429632 /usr/bin/conmon --api-version 1 -c 125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36 -u 125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata/pidfile -n supabase-pooler --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 125c33eed2f987c821b8ea32820b8855dab29904528bb4be883b09162efc2f36
1429994 /usr/bin/conmon --api-version 1 -c 2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930 -u 2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata/pidfile -n supabase-storage --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 2e5154f4d08f5ea0d1f0f446af9214b8508b1b2b8990a8e5f05980ffb3536930
1432778 /usr/bin/conmon --api-version 1 -c e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4 -u e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata/pidfile -n backend-users --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg e22a8a9a5b60e208683f88938bc3aaf0864c60f49ae3a5c56c5d9c835eefebd4
1739847 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /tmp/podman-1000/c533ab2ea3f5d2ba780e5f2892a46cb4/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
1739848 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/.serena/language_servers/static/TypeScriptLanguageServer/ts-lsp/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --cancellationPipeName /tmp/podman-1000/1339737dd73263ce3434bd3c1f6b0864/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
1945388 /home/devuser/.local/share/mise/installs/python/3.12.11/bin/python3.12 /home/devuser/.local/bin/podman-compose -f /home/devuser/work/CodeX/ITDO_ERP3/poc/event-backbone/local/podman-compose.yml up -d --build
2246589 /usr/bin/conmon --api-version 1 -c db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0 -u db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0/userdata/pidfile -n local_rabbitmq_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg db2160cc7577b2eb87bc294408bb215a4213224e595b27951a145ad385ff63f0
2246791 /usr/bin/conmon --api-version 1 -c 39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032 -u 39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032/userdata/pidfile -n local_redis_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 39fb197491edd2d17915769c3267693aeb2361a7bbb8c1a037f2fd48fd04d032
2246926 /usr/bin/conmon --api-version 1 -c 1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54 -u 1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54/userdata/pidfile -n local_minio_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 1ec5629e6f320bf16e42c8b95ad983abcbc443a412b827e731cb094874352a54
2247150 /usr/bin/conmon --api-version 1 -c a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1 -u a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1/userdata/pidfile -n local_loki_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg a45c35eadba4d13138c0794b8c8320260e6ea93fe4be90f9aed41a7bf5b6bec1
2247317 /usr/bin/conmon --api-version 1 -c 405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce -u 405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce/userdata/pidfile -n local_promtail_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 405e945f31db7b24eb6ba49e61f217562400122aecbe57ff47c4e47a19f845ce
2248005 /usr/bin/conmon --api-version 1 -c 8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f -u 8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f/userdata/pidfile -n local_consumer_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 8b931b645b2287eefa444d2a4b5e101b91f3c6763efe77f8af30fe308244920f
2248237 /usr/bin/conmon --api-version 1 -c 37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58 -u 37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58/userdata/pidfile -n local_pm-service_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 37000d0d2d70cebd017e8f54cb32e6ef57b537f6f05ce45b4b9edccc31d77d58
2248769 sh -c next dev --hostname 0.0.0.0 --port 4103
2248770 node /home/devuser/work/CodeX/ITDO_ERP3/ui-poc/node_modules/.bin/next dev --hostname 0.0.0.0 --port 4103
2301234 bash -lc gh pr create --base main --head feature/podman-status-telemetry-check --title "Podmanステータス確認にTelemetryシード検証を追加" --body "## 概要 - `scripts/podman_status.sh` に Telemetry seed 件数の自動検証を追加 - JSON 解析エラー／閾値不足時のメッセージを整備し、Python3 未インストール時はスキップ - `docs/podman-ui-workflow.md` に利用方法と環境変数の説明を追記  ## テスト - PM_PORT=3103 UI_PORT=4103 scripts/podman_status.sh"
2301238 bash scripts/podman_status.sh
2301268 /usr/bin/conmon --api-version 1 -c 8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e -u 8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e/userdata/pidfile -n local_grafana_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e
2301313 /usr/bin/podman --root /home/devuser/.local/share/containers/storage --runroot /mnt/wslg/runtime-dir/containers --log-level warning --cgroup-manager cgroupfs --tmpdir /mnt/wslg/runtime-dir/libpod/tmp --network-config-dir  --network-backend netavark --volumepath /home/devuser/.local/share/containers/storage/volumes --db-backend sqlite --transient-store=false --runtime crun --storage-driver overlay --events-backend journald container cleanup 8538fb3abceed792babbb061b430e9868d384980e74b42475e2aa9f654696e3e
3752710 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/typescript/lib/tsserver.js --serverMode partialSemantic --useInferredProjectPerProjectRoot --disableAutomaticTypingAcquisition --cancellationPipeName /tmp/podman-1000/d55dc15a00ea46e00e21b310a7e48cfe/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
3752711 /home/devuser/.local/share/mise/installs/node/22.19.0/bin/node /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/typescript/lib/tsserver.js --useInferredProjectPerProjectRoot --cancellationPipeName /tmp/podman-1000/8a2c03339713c63cb3b39b9a4bf4d496/tscancellation* --locale en --validateDefaultNpmLocation --useNodeIpc
3753635 /usr/bin/conmon --api-version 1 -c 021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46 -u 021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata/pidfile -n local_rabbitmq_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 021479dead9daffa87ed2b08288bdf7fe291fd2eb68ce26b3c5ec0dd13f94a46
3754172 /usr/bin/conmon --api-version 1 -c 86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c -u 86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata/pidfile -n local_redis_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 86dfff48ec0220078cfc6de5b7793c1fcc81d9914532790d05cb25994353e29c
3754343 /usr/bin/conmon --api-version 1 -c b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282 -u b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata/pidfile -n local_minio_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg b67e0a9a405828b6c88ea6db9df0a09ee1b7114e3240b616e0177c5ff8b5f282
3754817 /usr/bin/conmon --api-version 1 -c c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5 -u c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata/pidfile -n local_loki_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg c952945d8db70e66abf69fa61d684549e2ea49d26c5f72509e2893e96b9b7bc5
3755108 /usr/bin/conmon --api-version 1 -c 4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc -u 4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata/pidfile -n local_promtail_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 4d7898eff890bdfb94c1623ea8eb31715db7b8358da182eddf12ea9e31fe84dc
3756808 /usr/bin/conmon --api-version 1 -c fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566 -u fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata/pidfile -n local_consumer_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg fcb0d51a608a850807e80a8c61528af123e31804d293815838170fe522111566
3757384 /usr/bin/conmon --api-version 1 -c 400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507 -u 400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507 -r /usr/bin/crun -b /home/devuser/.local/share/containers/storage/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata -p /mnt/wslg/runtime-dir/containers/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata/pidfile -n local_pm-service_1 --exit-dir /mnt/wslg/runtime-dir/libpod/tmp/exits --full-attach -l journald --log-level warning --syslog --runtime-arg --log-format=json --runtime-arg --log --runtime-arg=/mnt/wslg/runtime-dir/containers/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata/oci-log --conmon-pidfile /mnt/wslg/runtime-dir/containers/overlay-containers/400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507/userdata/conmon.pid --exit-command /usr/bin/podman --exit-command-arg --root --exit-command-arg /home/devuser/.local/share/containers/storage --exit-command-arg --runroot --exit-command-arg /mnt/wslg/runtime-dir/containers --exit-command-arg --log-level --exit-command-arg warning --exit-command-arg --cgroup-manager --exit-command-arg cgroupfs --exit-command-arg --tmpdir --exit-command-arg /mnt/wslg/runtime-dir/libpod/tmp --exit-command-arg --network-config-dir --exit-command-arg  --exit-command-arg --network-backend --exit-command-arg netavark --exit-command-arg --volumepath --exit-command-arg /home/devuser/.local/share/containers/storage/volumes --exit-command-arg --db-backend --exit-command-arg sqlite --exit-command-arg --transient-store=false --exit-command-arg --runtime --exit-command-arg crun --exit-command-arg --storage-driver --exit-command-arg overlay --exit-command-arg --events-backend --exit-command-arg journald --exit-command-arg container --exit-command-arg cleanup --exit-command-arg 400edfe4c9da411fc076fc54124c0e814cc45b7dc10c55005502ede46fd32507
4192607 /home/devuser/.local/share/mise/installs/python/3.12.11/bin/python3.12 /home/devuser/.local/bin/podman-compose -f /home/devuser/work/CodeX/ITDO_ERP3/poc/event-backbone/local/podman-compose.yml ps に Telemetry seed 件数の自動検証を追加
- JSON 解析エラー／閾値不足時のメッセージを整備し、Python3 未インストール時はスキップ
-  に利用方法と環境変数の説明を追記

## テスト
- PM_PORT=3103 UI_PORT=4103 scripts/podman_status.sh