### PR TITLE
Grafanaアラート定義の起動エラーを解消

### DIFF
--- a/poc/event-backbone/local/grafana/provisioning/alerting/telemetry.yaml
+++ b/poc/event-backbone/local/grafana/provisioning/alerting/telemetry.yaml
@@ -11,6 +11,11 @@ groups:
         data:
           - refId: A
             datasourceUid: poc-loki
+            relativeTimeRange:
+              from: 300
+              to: 0
+            intervalMs: 60000
+            maxDataPoints: 43200
             model:
               datasource:
                 type: loki
@@ -28,10 +33,10 @@ groups:
           - refId: C
             datasourceUid: -100
             model:
-              expression: B > 0
+              expression: $B > 0
               type: math
         noDataState: OK
-        execErrState: ALERTING
+        execErrState: Alerting
         for: 5m
         annotations:
           summary: "Telemetry fallback events detected"


### PR DESCRIPTION
## 概要
- TelemetryFallbackSpike ルールの  を Grafana 10 用の表記 () に修正
- Loki クエリに  等のメタ情報を追加し、Grafana 起動時の  を防止
- math 式の参照を  に変更し、評価エラーを解消

## テスト
- CHECK_GRAFANA_ALERTS=false CHECK_GRAFANA_DASHBOARDS=false CHECK_GRAFANA_MANIFEST=false PM_PORT=3103 USE_MINIO=false scripts/poc_live_smoke.sh （RabbitMQ DNS 解決タイミングにより pm-service ヘルス待ちで失敗）