### PR TITLE
PoC smokeでLokiフォールバックをホストへ切替

### DIFF
--- a/scripts/poc_live_smoke.sh
+++ b/scripts/poc_live_smoke.sh
@@ -201,6 +201,7 @@ enable_host_internal_fallback() {
   export MINIO_ENDPOINT="${host}"
   export MINIO_PUBLIC_ENDPOINT="${host}"
   export MINIO_PUBLIC_PORT="${MINIO_HOST_PORT}"
+  export POC_LOKI_URL="http://localhost:${LOKI_PORT}"
   export PODMAN_HOST_FALLBACK_ACTIVE=true
 }
 
@@ -211,7 +212,7 @@ should_attempt_host_fallback() {
 start_stack() {
   echo "[stack] restarting PoC stack"
   if [[ "${PODMAN_HOST_FALLBACK_ACTIVE}" == "true" ]]; then
-    echo "[stack] host fallback active (AMQP_URL=${AMQP_URL:-unset}, REDIS_URL=${REDIS_URL:-unset}, MINIO_ENDPOINT=${MINIO_ENDPOINT:-unset})"
+    echo "[stack] host fallback active (AMQP_URL=${AMQP_URL:-unset}, REDIS_URL=${REDIS_URL:-unset}, MINIO_ENDPOINT=${MINIO_ENDPOINT:-unset}, POC_LOKI_URL=${POC_LOKI_URL:-unset})"
   fi
   (cd "${PROJECT_DIR}" && podman-compose -f "${COMPOSE_FILE}" down >/dev/null 2>&1) || true
   (cd "${PROJECT_DIR}" && podman-compose -f "${COMPOSE_FILE}" up -d --build)


### PR DESCRIPTION
## 概要
- `scripts/poc_live_smoke.sh` のホストフォールバック処理で Loki もホスト側 (`http://localhost:${LOKI_PORT}`) を参照するようにし、Grafana アラートが DNS 不調時でも継続利用できるようにしました
- フォールバック有効時に `POC_LOKI_URL` をログへ出力し、デバッグ時に切り替え状況を確認しやすくしました

## テスト
- bash -n scripts/poc_live_smoke.sh
