### PR TITLE
PoC smoke用envサンプルのフォールバック設定追加

### DIFF
--- a/scripts/.env.poc_live_smoke.example
+++ b/scripts/.env.poc_live_smoke.example
@@ -11,6 +11,9 @@ USE_MINIO=true
 CHECK_GRAFANA_ALERTS=true
 CHECK_GRAFANA_DASHBOARDS=true
 RUN_METRICS_STRESS=true
+PODMAN_AUTO_HOST_FALLBACK=true
+HOST_INTERNAL_ADDR=host.containers.internal
+PODMAN_HOST_FALLBACK_ACTIVE=false
 
 # Health check timeouts (seconds)
 TIMEOUT_SECONDS=120
@@ -34,10 +37,19 @@ GRAFANA_HOST=localhost
 GRAFANA_PORT=3000
 GRAFANA_USER=admin
 GRAFANA_PASSWORD=admin
+POC_LOKI_URL=http://loki:3100
 
 # Slack notifications (optional)
 # SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 # SLACK_NOTIFY_ON_SUCCESS=false
-
 # Log directory (optional)
 # LOG_DIR=/tmp/poc-smoke-logs
+
+# Telemetry seed verification
+TELEMETRY_SEED_ENDPOINT=http://localhost:${PM_PORT}/api/v1/telemetry/ui?limit=50
+TELEMETRY_MIN_SEEDED=5
+TELEMETRY_SEED_AUTO_RESET=false
+TELEMETRY_SEED_RESET_WITH_MINIO=false
+TELEMETRY_SEED_RESET_TIMEOUT=60
+TELEMETRY_SEED_MAX_ATTEMPTS=2
+TELEMETRY_SEED_SETTLE_SECONDS=2


### PR DESCRIPTION
## 概要
- `scripts/.env.poc_live_smoke.example` にフォールバック関連 (`PODMAN_AUTO_HOST_FALLBACK`, `HOST_INTERNAL_ADDR`, `POC_LOKI_URL`) と Telemetry seed 設定 (`TELEMETRY_SEED_AUTO_RESET`, `TELEMETRY_SEED_MAX_ATTEMPTS` など) のテンプレート値を追加しました
- 併せて既存のセクションを整理し、ローカル実行時に必要な設定がサンプルから参照しやすいようにしています

## テスト
- なし（ドキュメント更新のみ）
