### PR TITLE
PoC smoke envサンプルにフォールバック設定を追記

### DIFF
--- a/scripts/.env.poc_live_smoke.example
+++ b/scripts/.env.poc_live_smoke.example
@@ -11,6 +11,10 @@ USE_MINIO=true
 CHECK_GRAFANA_ALERTS=true
 CHECK_GRAFANA_DASHBOARDS=true
 RUN_METRICS_STRESS=true
+# Fallback (namesはスクリプト内の環境変数と揃えています)
+# PODMAN_AUTO_HOST_FALLBACK=false
+# HOST_INTERNAL_ADDR=host.containers.internal
+# POC_LOKI_URL=http://loki:3100
 
 # Health check timeouts (seconds)
 TIMEOUT_SECONDS=120
@@ -41,3 +45,12 @@ GRAFANA_PASSWORD=admin
 
 # Log directory (optional)
 # LOG_DIR=/tmp/poc-smoke-logs
+
+# Telemetry seed verification
+# TELEMETRY_SEED_ENDPOINT=http://localhost:${PM_PORT}/api/v1/telemetry/ui?limit=50
+# TELEMETRY_MIN_SEEDED=5
+# TELEMETRY_SEED_AUTO_RESET=false
+# TELEMETRY_SEED_RESET_WITH_MINIO=false
+# TELEMETRY_SEED_RESET_TIMEOUT=60
+# TELEMETRY_SEED_MAX_ATTEMPTS=2
+# TELEMETRY_SEED_SETTLE_SECONDS=2


### PR DESCRIPTION
## 概要
- `scripts/.env.poc_live_smoke.example` にフォールバック関連の設定（`PODMAN_AUTO_HOST_FALLBACK`, `HOST_INTERNAL_ADDR`, `POC_LOKI_URL`）と Telemetry seed 再検証用の変数をコメント付きで追記しました
- すべて既存スクリプトで参照されている環境変数で、ローカル実行時に上書きしやすいよう整理しています

## テスト
- なし（サンプルファイルのコメント追加のみ）
