### PR TITLE
Slack通知にTelemetry seeded件数を表示

### DIFF
--- a/scripts/poc_live_smoke.sh
+++ b/scripts/poc_live_smoke.sh
@@ -422,7 +422,9 @@ PY2
   fi
   echo "[health] telemetry seed ok - $output"
   TELEMETRY_SEED_STATUS="verified"
-  if [[ "$output" =~ seeded\ events:\ ([0-9]+) ]]; then
+  # Parser output example: "seeded events: 5 (expected >= 5)"
+  local seeded_regex='seeded events: ([0-9]+)'
+  if [[ "$output" =~ $seeded_regex ]]; then
     TELEMETRY_SEEDED_COUNT="${BASH_REMATCH[1]}"
   else
     TELEMETRY_SEEDED_COUNT="unknown"


### PR DESCRIPTION
## 概要
- Telemetry seed 検証で算出した seeded 件数を `TELEMETRY_SEEDED_COUNT` に保持し、Slack の成功通知に `(seeded=…)` として表示するようにしました
- 失敗パターン（Python 不在・エンドポイント未到達など）でも件数を把握しやすいように、ステータスに応じて `n/a` や `failed` を設定しています

## テスト
- bash -n scripts/poc_live_smoke.sh
