### PR TITLE
ドキュメント: PoC Smoke ガイドへの導線整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Next.js ベースの UI PoC については、以下の手順でエンドツー�
    TIMEOUT_SECONDS=180 scripts/poc_live_smoke.sh --tests-only
    ```
    - Podman Compose で pm-service / RabbitMQ / Redis / MinIO / Grafana を起動し、ライブ API に対する Playwright シナリオとメトリクス監視を自動実行します。
-   - Slack Webhook を設定すると失敗通知も送信されます。詳細は `scripts/.env.poc_live_smoke.example` を参照してください。
+   - Slack Webhook を設定すると失敗通知も送信されます。詳細は `scripts/.env.poc_live_smoke.example` と [PoC Live Smoke Tests](docs/poc_live_smoke.md) を参照してください。
 
 3. **CI 監視**
    - GitHub Actions の **PoC Live Smoke** ワークフローでは MinIO 有効/無効の 2 パターンで上記スモークを毎日／手動で実行できます。

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@
 - [Live Testing Guide](live-testing.md)
 
 ## Podman Smoke
-- [PoC Smoke Tests](poc_live_smoke.md)
+- [PoC Smoke Tests](poc_live_smoke.md) - Slack通知やフォールバック設定の詳細ガイド


### PR DESCRIPTION
## 概要
- ルート `README.md` の Podman ライブスモーク説明に `docs/poc_live_smoke.md` へのリンクを追加し、詳細ガイドへ直接遷移できるようにしました
- `docs/README.md` のリンクにも簡単な説明を添え、Slack 通知やフォールバック設定の参照先が分かりやすくなります

## テスト
- なし（ドキュメント更新のみ）
