### PR TITLE
Add host fallback modes to Podman UI launcher

### DIFF
--- a/docs/poc_live_smoke.md
+++ b/docs/poc_live_smoke.md
@@ -30,6 +30,8 @@ Slack 通知例:
 | `HOST_INTERNAL_ADDR` | `host.containers.internal` | フォールバック時に使用するホスト名。Podman Desktop など環境に応じて変更できます。 |
 | `POC_LOKI_URL` | `http://loki:3100` | Grafana の Loki データソース URL。フォールバックが発動した場合は自動的に `http://localhost:${LOKI_PORT}` へ切り替わります。 |
 
+> 互換性のため `PODMAN_AUTO_HOST_FALLBACK=false` を指定するとフォールバックが完全に無効化され、`PODMAN_HOST_FALLBACK_MODE` が `auto` の場合でも `never` に強制されます。新しいモード指定を優先的に使用してください。
+
 ## Telemetry seed 検証
 
 | 変数 | 既定値 | 役割 |

--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -18,6 +18,7 @@
    - ログ: `ui-poc/.next/dev.log`
    - コンテナ確認: `cd poc/event-backbone/local && podman-compose -f podman-compose.yml ps`
    - WSL2 などで毎回フォールバックが必要な場合は `--fallback-mode force` を付けると初回から `host.containers.internal` を利用します。
+   - 既存の `PODMAN_AUTO_HOST_FALLBACK=false` を設定している場合でも動作は維持されますが、新しい `PODMAN_HOST_FALLBACK_MODE`（`auto`/`force`/`never`）の利用を推奨します。
 
 2. 動作確認
    ```bash

--- a/scripts/run_podman_ui_poc.sh
+++ b/scripts/run_podman_ui_poc.sh
@@ -204,6 +204,9 @@ should_attempt_host_fallback() {
     force|auto)
       [[ "${fallback_attempted}" != "true" ]]
       ;;
+    never)
+      return 1
+      ;;
     *)
       return 1
       ;;


### PR DESCRIPTION
## Summary
- add --fallback-mode flag and PODMAN_HOST_FALLBACK_MODE env for run_podman_ui_poc.sh
- allow forcing host.containers.internal from the first podman-compose run to avoid double startup
- document the new options in podman UI workflow and smoke docs

## Testing
- bash -n scripts/run_podman_ui_poc.sh
- scripts/run_podman_ui_poc.sh --help

Fixes #165