### PR TITLE
Export Grafana dashboards from live tests

### DIFF
--- a/docs/podman-ui-workflow.md
+++ b/docs/podman-ui-workflow.md
@@ -91,6 +91,9 @@ PoC スタックに対して Playwright ライブスイートを実行したい�
 ```bash
 # 例: MinIO 有効でライブテストを走らせる
 PM_PORT=3105 UI_PORT=4105 scripts/podman_live_tests.sh --with-minio
+
+# Grafana ダッシュボードをログにエクスポート
+PODMAN_LIVE_EXPORT_DASHBOARDS=true scripts/podman_live_tests.sh
 ```
 
 任意のポートやフォールバック設定は環境変数で上書き可能です（例: `PODMAN_HOST_FALLBACK_MODE=never scripts/podman_live_tests.sh`）。実行が完了するとスタックは自動的に停止します。

--- a/scripts/podman_live_tests.sh
+++ b/scripts/podman_live_tests.sh
@@ -48,8 +48,43 @@ fi
 export PM_PORT="${PM_PORT:-3105}"
 export UI_PORT="${UI_PORT:-4105}"
 export PODMAN_HOST_FALLBACK_MODE="${PODMAN_HOST_FALLBACK_MODE:-force}"
+EXPORT_DASHBOARDS=${PODMAN_LIVE_EXPORT_DASHBOARDS:-false}
 
 printf '[live-tests] Starting Playwright live suite (PM_PORT=%s, UI_PORT=%s, fallback=%s)\n' \
   "${PM_PORT}" "${UI_PORT}" "${PODMAN_HOST_FALLBACK_MODE}"
 
-exec "${RUNNER}" --tests-only "$@"
+LIVE_TEST_LOG_DIR="${ROOT_DIR}/logs/podman-live-tests"
+mkdir -p "${LIVE_TEST_LOG_DIR}"
+timestamp=$(date +"%Y%m%d_%H%M%S")
+log_file="${LIVE_TEST_LOG_DIR}/run_${timestamp}.log"
+echo "[live-tests] Writing combined output to ${log_file}" >&2
+
+{
+  echo "PM_PORT=${PM_PORT}"
+  echo "UI_PORT=${UI_PORT}"
+  echo "PODMAN_HOST_FALLBACK_MODE=${PODMAN_HOST_FALLBACK_MODE}"
+  echo "EXPORT_DASHBOARDS=${EXPORT_DASHBOARDS}"
+  echo
+} >"${log_file}"
+
+set +e
+"${RUNNER}" --tests-only "$@" | tee -a "${log_file}"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ ${EXPORT_DASHBOARDS,,} == "true" ]]; then
+  export_dir="${LIVE_TEST_LOG_DIR}/dashboards_${timestamp}"
+  mkdir -p "${export_dir}"
+  container_name="local_grafana_1"
+  if podman ps --format '{{.Names}}' | grep -q "${container_name}"; then
+    if podman cp "${container_name}:/var/lib/grafana/dashboards/." "${export_dir}"; then
+      echo "[live-tests] Exported dashboards to ${export_dir}" | tee -a "${log_file}"
+    else
+      echo "[live-tests] Failed to export dashboards from ${container_name}" | tee -a "${log_file}" >&2
+    fi
+  else
+    echo "[live-tests] Grafana container ${container_name} not found; skipping export" | tee -a "${log_file}"
+  fi
+fi
+
+exit ${status}


### PR DESCRIPTION
## Summary
- add PODMAN_LIVE_EXPORT_DASHBOARDS flag to scripts/podman_live_tests.sh to copy dashboards after the run
- log run metadata to logs/podman-live-tests/run_*.log and capture export location
- document the new option in docs/podman-ui-workflow.md

## Testing
- bash -n scripts/podman_live_tests.sh