### PR TITLE
Add filters to UI feedback CLI

### DIFF
--- a/docs/ui-poc-feedback-backlog.md
+++ b/docs/ui-poc-feedback-backlog.md
@@ -45,4 +45,10 @@ scripts/ui_feedback_issue_cli.js
 
 # 実際に Issue 化（Slack などと連携する場合はラベルを指定）
 scripts/ui_feedback_issue_cli.js --create --label "ui" --assignee @me
+
+# 特定セクションのみ（例: Telemetry）
+scripts/ui_feedback_issue_cli.js --section Telemetry --section "Cross-cutting"
+
+# 文字列フィルタを併用
+scripts/ui_feedback_issue_cli.js --contains fallback
 ```


### PR DESCRIPTION
## Summary
- allow specifying  (repeatable) and  filters when listing backlog items
- keep existing --create/--label/--assignee behaviour unchanged
- document the new options with examples in the backlog doc

## Testing
- scripts/ui_feedback_issue_cli.js --section Telemetry --contains seed