### PR TITLE
Add telemetry health collector script

### DIFF
--- a/docs/podman-telemetry-dashboard.md
+++ b/docs/podman-telemetry-dashboard.md
@@ -43,5 +43,13 @@ PoC で流れる Telemetry イベントやメトリクスを Grafana/Loki から
 - Telemetry 画面の操作後に上記クエリを実行し、UI 上でのアクションがログへ反映されているか検証してください。
 - Slack 通知と組み合わせて、`scripts/podman_status.sh` が送信した `telemetry seed ok/failure` メッセージのタイムスタンプと Grafana のログの整合性を確認すると原因分析が容易になります。
 
+## Loki への追加取り込み
+
+`scripts/collect_telemetry_health.sh` を cron 等で実行すると `/health/telemetry` の結果が `logs/telemetry-health/telemetry-health.ndjson` に追記されます。Promtail の additional scrape 対象に含めることで Grafana からステータスを確認できます。
+
+```bash
+PM_PORT=3103 OUTPUT_DIR=/var/log/poc scripts/collect_telemetry_health.sh
+```
+
 ---
 必要に応じてこのガイドを更新し、よく使うログクエリやパネル構成を蓄積してください。

--- a/scripts/collect_telemetry_health.sh
+++ b/scripts/collect_telemetry_health.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PM_PORT="${PM_PORT:-3001}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${ROOT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+OUTPUT_DIR="${OUTPUT_DIR:-${ROOT_DIR}/logs/telemetry-health}"
+TIMESTAMP=$(date -Is)
+URL="${TELEMETRY_HEALTH_ENDPOINT:-http://localhost:${PM_PORT}/health/telemetry}"
+
+mkdir -p "${OUTPUT_DIR}"
+OUT_FILE="${OUTPUT_DIR}/telemetry-health.ndjson"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[telemetry-health] ERROR: jq is required" >&2
+  exit 1
+fi
+
+response=$(curl -fsS "$URL" 2>/dev/null || true)
+status="error"
+message="request failed"
+if [[ -n "$response" ]]; then
+  status=$(printf '%s' "$response" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+  message=$(printf '%s' "$response" | jq -r '.message // ""' 2>/dev/null || echo "")
+fi
+
+message_json=$(printf '%s' "$message" | jq -Rs .)
+
+printf '{"timestamp":"%s","status":"%s","message":%s,"payload":%s}\n' \
+  "$TIMESTAMP" "$status" "$message_json" "${response:-null}" >> "$OUT_FILE"
+
+echo "[telemetry-health] appended snapshot to $OUT_FILE"


### PR DESCRIPTION
## Summary
- add a helper script that fetches the Podman telemetry health endpoint and stores snapshots in NDJSON
- document how to schedule the script and integrate the resulting file with Promtail

## Testing
- scripts/collect_telemetry_health.sh