### PR TITLE
Add pytest coverage for validation scripts

### DIFF
--- a/tests/python/test_validate_grafana_dashboards.py
+++ b/tests/python/test_validate_grafana_dashboards.py
@@ -1,0 +1,35 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT_DIR / "scripts" / "validate_grafana_dashboards.py"
+DASHBOARD_DIR = ROOT_DIR / "poc" / "event-backbone" / "local" / "grafana" / "dashboards"
+
+
+def run_dashboards(path: Path | None = None) -> subprocess.CompletedProcess[str]:
+    args = [sys.executable, str(SCRIPT)]
+    if path is not None:
+        args.append(str(path))
+    return subprocess.run(args, capture_output=True, text=True, check=False)
+
+
+def test_repository_dashboards_are_valid():
+    result = run_dashboards()
+    assert result.returncode == 0
+    assert "[grafana-validation] OK" in result.stdout
+
+
+def test_missing_title_fails(tmp_path):
+    invalid_dashboard = {
+        "uid": "example",
+        "panels": [],
+    }
+    dashboard_path = tmp_path / "bad-dashboard.json"
+    dashboard_path.write_text(json.dumps(invalid_dashboard), encoding="utf-8")
+
+    result = run_dashboards(tmp_path)
+    assert result.returncode == 2
+    assert "missing key 'title'" in result.stderr

--- a/tests/python/test_validate_smoke_summary.py
+++ b/tests/python/test_validate_smoke_summary.py
@@ -1,0 +1,61 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT_DIR / "scripts" / "validate_smoke_summary.py"
+SAMPLE = ROOT_DIR / "scripts" / "samples" / "example_poc_smoke_summary.json"
+
+
+def run_summary(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_example_summary_is_valid():
+    result = run_summary(SAMPLE)
+    assert result.returncode == 0
+    assert "[summary-validation] OK" in result.stdout
+
+
+def test_missing_required_section(tmp_path):
+    payload = {
+        "status": "success",
+        "failure_reason": "",
+        "runs": 1,
+        "attempt": 1,
+        "fallback_used": False,
+    }
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = run_summary(summary_path)
+    assert result.returncode == 2
+    assert "Missing key: telemetry" in result.stderr
+
+
+def test_numeric_string_validation(tmp_path):
+    payload = {
+        "status": "success",
+        "failure_reason": "",
+        "runs": 1,
+        "attempt": 1,
+        "fallback_used": False,
+        "telemetry": {
+            "status": "verified",
+            "seeded_count": "not-a-number",
+            "attempts": "1",
+        },
+    }
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = run_summary(summary_path)
+    assert result.returncode == 2
+    assert "telemetry: key 'seeded_count' must be numeric-like" in result.stderr


### PR DESCRIPTION
## Summary
- add subprocess-based pytest coverage for smoke summary and Grafana validators
- ensure missing keys and numeric string validation emit the expected errors

## Testing
- pytest tests/python