### PR TITLE
Harden podman live duration parsing

### DIFF
--- a/.github/workflows/podman-live-tests-notify.yml
+++ b/.github/workflows/podman-live-tests-notify.yml
@@ -49,7 +49,7 @@ if not value:
     sys.exit(0)
 
 try:
-    minutes = int(value) / 60000
+    minutes = round(int(value) / 60000, 1)
 except ValueError:
     sys.exit(0)
 else:


### PR DESCRIPTION
## Summary
- align workflow duration parsing with the defensive JSON handlers
- avoid printing invalid values when RUN_DURATION is missing or malformed

## Testing
- not applicable