### PR TITLE
Timesheets バルク処理に reject/resubmit を追加

### DIFF
--- a/ui-poc/src/features/timesheets/TimesheetsClient.tsx
+++ b/ui-poc/src/features/timesheets/TimesheetsClient.tsx
@@ -206,21 +206,32 @@ export function TimesheetsClient({ initialTimesheets }: TimesheetsClientProps) {
   const closeDialog = () => setDialog(initialDialog);
   const closeBulkDialog = () => setBulkDialog(initialBulkDialog);
 
+  const buildBulkActionPayload = useCallback(
+    (action: TimesheetAction, comment: string, reasonCode: string): ActionPayload | undefined => {
+      const trimmedComment = comment.trim();
+      const trimmedReason = reasonCode.trim();
+      if (!trimmedComment && !(action === "reject" && trimmedReason)) {
+        return undefined;
+      }
+      return {
+        comment: trimmedComment || undefined,
+        reasonCode: action === "reject" ? (trimmedReason || undefined) : undefined,
+      };
+    },
+    [],
+  );
+
   const submitBulkDialog = () => {
-    const targets = timesheets.filter((entry) => bulkDialog.targetIds.includes(entry.id));
-    if (targets.length === 0) {
+    if (bulkTargets.length === 0) {
       closeBulkDialog();
       return;
     }
-    const comment = bulkDialog.comment.trim();
-    const reason = bulkDialog.reasonCode.trim();
-    const payload: ActionPayload | undefined = comment || (bulkDialog.action === "reject" && reason)
-      ? {
-          comment: comment || undefined,
-          reasonCode: bulkDialog.action === "reject" ? (reason || undefined) : undefined,
-        }
-      : undefined;
-    void executeBulkAction(bulkDialog.action, targets, payload);
+    const payload = buildBulkActionPayload(
+      bulkDialog.action,
+      bulkDialog.comment,
+      bulkDialog.reasonCode,
+    );
+    void executeBulkAction(bulkDialog.action, bulkTargets, payload);
     closeBulkDialog();
   };
 


### PR DESCRIPTION
## Summary
- 選択中のタイムシートに対して Reject/Resubmit もバルク実行できるようにし、コメント・理由コードをまとめて入力するダイアログを追加しました
- バルク処理は Promise.allSettled で並列実行し、成功した ID を未選択に戻してメッセージを表示するよう整理しました
- 対象件数のプレビューや理由コード選択などを含む UI を追加し、既存の単票ダイアログとの整合をとりました

## Testing
- npm run lint (ui-poc)
