### PR TITLE
Projects 共有リンク向け Slack テンプレ CLI を追加

### DIFF
--- a/scripts/project-share-slack.js
+++ b/scripts/project-share-slack.js
@@ -106,7 +106,7 @@ const tagList = [
 
 const bulletLines = [];
 
-if (status && status !== 'all') {
+if (params.has('status') && status !== 'all') {
   const label = statusLabels.get(status) ?? status;
   bulletLines.push(`• ステータス: *${label}*`);
 }
@@ -130,7 +130,7 @@ if (bulletLines.length === 0) {
 }
 
 const title = options.title ?? 'Projects 共有リンク';
-const timestamp = new Date().toLocaleString('ja-JP', { hour12: false });
+const timestamp = new Date().toLocaleString('ja-JP', { hour12: false, timeZone: 'Asia/Tokyo' });
 
 const message = [
   `:clipboard: *${title}* _(${timestamp})_`,


### PR DESCRIPTION
## Summary
- Projects 共有リンクからステータスやキーワードを抽出し、Slack への貼り付けメッセージを生成する CLI スクリプトを追加しました
-  や  などのオプションで簡易的にメッセージをカスタマイズできます
- スクリプト内で URL を検証し、日本語ロケールの日付でタイムスタンプを付与しています

## Testing
- node scripts/project-share-slack.js --url https://example.com/projects?status=active --title テスト --notes note
