### PR TITLE
Projects REST API の件数メタを COUNT ベースに更新

### DIFF
--- a/poc/event-backbone/local/services/pm-service/__tests__/rest.test.js
+++ b/poc/event-backbone/local/services/pm-service/__tests__/rest.test.js
@@ -77,6 +77,7 @@ describe('Projects REST API pagination meta', () => {
 
     if (projectSeed.length > 2) {
       expect(first.body.next_cursor).toBeDefined();
+      const firstPageIds = first.body.items.map((item) => item.id);
       const next = await request(server.app)
         .get('/api/v1/projects')
         .query({ first: 2, after: first.body.next_cursor })
@@ -85,7 +86,7 @@ describe('Projects REST API pagination meta', () => {
       expect(next.body.meta.total).toBe(projectSeed.length);
       expect(next.body.meta.returned).toBeLessThanOrEqual(2);
       if (next.body.meta.returned > 0) {
-        expect(next.body.items.some((item) => item.id === first.body.items[0].id)).toBe(false);
+        expect(next.body.items.some((item) => firstPageIds.includes(item.id))).toBe(false);
       }
     } else {
       expect(first.body.next_cursor).toBeUndefined();

--- a/poc/event-backbone/local/services/pm-service/index.js
+++ b/poc/event-backbone/local/services/pm-service/index.js
@@ -904,10 +904,14 @@ async function main() {
     const limitRaw = Number.parseInt(first, 10);
     const hasExplicitLimit = Number.isFinite(limitRaw) && limitRaw > 0;
     const DEFAULT_LIMIT = 24;
-    const limit = hasExplicitLimit ? Math.min(limitRaw, 100) : filtered.length || DEFAULT_LIMIT;
+    const limit = hasExplicitLimit
+      ? Math.min(limitRaw, 100)
+      : filtered.length > 0
+        ? filtered.length
+        : DEFAULT_LIMIT;
     const cursorValue = typeof after === 'string' ? after.trim() : '';
     const cursorIndex = cursorValue
-      ? filtered.findIndex((project) => project.id === cursorValue || project.code === cursorValue)
+      ? filtered.findIndex((project) => project.id === cursorValue)
       : -1;
     const startIndex = cursorIndex >= 0 ? cursorIndex + 1 : 0;
     const slice = hasExplicitLimit ? filtered.slice(startIndex, startIndex + limit) : filtered;

--- a/poc/event-backbone/local/services/pm-service/test-utils/createTestServer.js
+++ b/poc/event-backbone/local/services/pm-service/test-utils/createTestServer.js
@@ -441,10 +441,14 @@ export function createTestServer(options = {}) {
       const limitRaw = Number.parseInt(first, 10);
       const hasExplicitLimit = Number.isFinite(limitRaw) && limitRaw > 0;
       const DEFAULT_LIMIT = 24;
-      const limit = hasExplicitLimit ? Math.min(limitRaw, 100) : filtered.length || DEFAULT_LIMIT;
+      const limit = hasExplicitLimit
+        ? Math.min(limitRaw, 100)
+        : filtered.length > 0
+          ? filtered.length
+          : DEFAULT_LIMIT;
       const cursorValue = typeof after === 'string' ? after.trim() : '';
       const cursorIndex = cursorValue
-        ? filtered.findIndex((project) => project.id === cursorValue || project.code === cursorValue)
+        ? filtered.findIndex((project) => project.id === cursorValue)
         : -1;
       const startIndex = cursorIndex >= 0 ? cursorIndex + 1 : 0;
       const slice = hasExplicitLimit ? filtered.slice(startIndex, startIndex + limit) : filtered;


### PR DESCRIPTION
## Summary
-  で first/after を受け取り、meta.total をフィルタ後の件数、meta.returned を返却件数として返すようにしました
- next_cursor を追加し、デフォルトでは全件返しつつ first 指定時は cursor でページングできるようにしました
- テスト用 createTestServer と REST テストを更新し、カウントが status フィルタ後でも正しいことを確認しています

## Testing
- npm test (poc/event-backbone/local/services/pm-service)
