### PR TITLE
SSR 初期化済み Projects 一覧での二重フェッチを防止

### DIFF
--- a/ui-poc/src/features/projects/ProjectsClient.tsx
+++ b/ui-poc/src/features/projects/ProjectsClient.tsx
@@ -94,6 +94,7 @@ export function ProjectsClient({ initialProjects }: ProjectsClientProps) {
 
   const source: QuerySource = meta.fallback ? "mock" : "api";
   const apiReturned = meta.returned ?? projects.length;
+  const initialFetchSkippedRef = useRef(false);
 
   const router = useRouter();
   const pathname = usePathname();
@@ -781,6 +782,10 @@ export function ProjectsClient({ initialProjects }: ProjectsClientProps) {
   }, [normalizeTagLabel]);
 
   useEffect(() => {
+    if (!initialFetchSkippedRef.current) {
+      initialFetchSkippedRef.current = true;
+      return;
+    }
     void fetchProjects(filter, appliedKeyword, {
       manager: appliedManager,
       health: appliedHealth || undefined,


### PR DESCRIPTION
## Summary
- ProjectsClient の初回 useEffect で SSR 初期データを尊重し、hydration 直後の無駄な再フェッチをスキップしました
- 以後フィルタが変更された場合は既存の fetchProjects が動くため挙動は維持されます

## Testing
- npm run lint (ui-poc)
