### PR TITLE
Telemetry の Slack リンクをワークスペース URL へ変換

### DIFF
--- a/ui-poc/README.md
+++ b/ui-poc/README.md
@@ -11,6 +11,8 @@ npm install
 cp .env.local.example .env.local  # 必要に応じて API エンドポイントを調整
 ```
 
+`.env.local` に `NEXT_PUBLIC_SLACK_WORKSPACE_URL=https://example.slack.com` を設定すると、Telemetry 画面の Slack リンクが自社ワークスペースの URL へ変換されます。
+
 ## 起動
 
 ### バックエンドとフロントを個別に起動する場合

--- a/ui-poc/src/features/telemetry/TelemetryClient.tsx
+++ b/ui-poc/src/features/telemetry/TelemetryClient.tsx
@@ -134,9 +134,13 @@ export function TelemetryClient({ initialData, pollIntervalMs }: TelemetryClient
   );
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const selectedItem = useMemo(() => (selectedIndex !== null ? renderedItems[selectedIndex] ?? null : null), [renderedItems, selectedIndex]);
+  const slackWorkspaceBaseUrl = process.env.NEXT_PUBLIC_SLACK_WORKSPACE_URL ?? null;
   const { projectLinks, slackLinks } = useMemo(() => {
-    return collectRelatedLinks(selectedItem?.detail ?? null, { projectsPagePath: PROJECTS_PAGE_PATH });
-  }, [selectedItem]);
+    return collectRelatedLinks(selectedItem?.detail ?? null, {
+      projectsPagePath: PROJECTS_PAGE_PATH,
+      slackWorkspaceBaseUrl,
+    });
+  }, [selectedItem, slackWorkspaceBaseUrl]);
 
   const highlightMatches = useMemo(() => {
     if (!highlightKey) return new Set<number>();

--- a/ui-poc/src/features/telemetry/__tests__/link-utilities.test.ts
+++ b/ui-poc/src/features/telemetry/__tests__/link-utilities.test.ts
@@ -67,4 +67,17 @@ describe('collectRelatedLinks', () => {
     expect(projectLinks[0].href).toBe('/projects?keyword=DX-2025');
     expect(projectLinks[0].label).toBe('Projects: DX-2025');
   });
+
+  it('rewrites Slack links when workspace base URL is provided', () => {
+    const detail = {
+      audit: {
+        urls: ['https://slack.com/archives/ABC123/p1680000000000'],
+      },
+    };
+
+    const { slackLinks } = collectRelatedLinks(detail, {
+      slackWorkspaceBaseUrl: 'https://itdo-workspace.slack.com/',
+    });
+    expect(slackLinks).toEqual(['https://itdo-workspace.slack.com/archives/ABC123/p1680000000000']);
+  });
 });


### PR DESCRIPTION
## Summary
- `collectRelatedLinks` に `slackWorkspaceBaseUrl` オプションを追加し、`slack://` や `slack.com/app_redirect` のリンクをワークスペース固有 URL へ変換します
- `NEXT_PUBLIC_SLACK_WORKSPACE_URL` で環境設定できるよう TelemetryClient を更新しました
- ユニットテストを拡張し、カスタムベース URL の挙動を確認しています。また README に設定方法を追記しました

## Testing
- npm run test:unit (ui-poc)
- npm run lint (ui-poc)
