### PR TITLE
Support text/markdown/json output in share CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 - `make share-projects ARGS="--url https://example.com/projects?status=active"`
 - `cd ui-poc && PROJECTS_TITLE="Weekly Projects" npm run share:projects -- --url https://example.com/projects?status=active --notes "17 件をレビュー"`
+- `cd ui-poc && npm run share:projects -- --url https://example.com/projects?status=active --format json`
 
 `PROJECTS_URL` / `PROJECTS_TITLE` / `PROJECTS_NOTES` の各環境変数を上書きすることでサンプルスクリプトの出力を変更できます。
+
+`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。
 
 GitHub Actions には週次スケジュール (`Projects Slack Share Check`) を追加し、サンプルメッセージの生成が失敗しないかを継続的に確認しています。
 


### PR DESCRIPTION
## Summary
- share CLI に `--format` オプションを追加し、text / markdown / json の 3 形式に対応しました
- JSON 出力ではフィルタ条件やメッセージ原文も含めて返却し、ワークフロー連携しやすくしました
- README に新しい使い方の例とオプションの説明を追記しました

## Testing
- make lint
- node scripts/project-share-slack.js --url 'https://example.com/projects?status=active&manager=Yamada&tags=DX,SAP' --title テスト --notes メモ --format text
- node scripts/project-share-slack.js --url 'https://example.com/projects?status=active&manager=Yamada&tags=DX,SAP' --title テスト --notes メモ --format markdown
- node scripts/project-share-slack.js --url 'https://example.com/projects?status=active&manager=Yamada&tags=DX,SAP' --title テスト --notes メモ --format json
