### PR TITLE
Add share CLI vitest smoke tests

### DIFF
--- a/ui-poc/package.json
+++ b/ui-poc/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "share:projects": "node ../scripts/project-share-slack.js",
     "share:projects:sample": "npm run --silent share:projects -- --url ${PROJECTS_URL:-https://example.com/projects?status=active} --title \"${PROJECTS_TITLE:-CI Slack Share}\" --notes \"${PROJECTS_NOTES:-sample verification}\"",
-    "test:unit": "vitest run src/features/telemetry/__tests__/link-utilities.test.ts",
+    "test:unit": "vitest run src/features/telemetry/__tests__/link-utilities.test.ts tests/share-cli/project-share-slack.test.ts",
+    "test:share-cli": "vitest run tests/share-cli/project-share-slack.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:live": "E2E_EXPECT_API=true playwright test"
   },

--- a/ui-poc/tests/share-cli/project-share-slack.test.ts
+++ b/ui-poc/tests/share-cli/project-share-slack.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const scriptPath = path.resolve(__dirname, "../../../scripts/project-share-slack.js");
+const baseArgs = [
+  "--url",
+  "https://example.com/projects?status=active&manager=Yamada&tags=DX,SAP",
+  "--title",
+  "テスト",
+  "--notes",
+  "メモ",
+];
+
+const runScript = (extraArgs: string[] = []) =>
+  spawnSync(process.execPath, [scriptPath, ...baseArgs, ...extraArgs], {
+    encoding: "utf-8",
+  });
+
+describe("project-share-slack CLI", () => {
+  test("outputs text format by default", () => {
+    const result = runScript();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(":clipboard: *テスト* _(");
+    expect(result.stdout).toContain("• ステータス: *Active*");
+    expect(result.stdout).toContain("• タグ: DX, SAP");
+  });
+
+  test("outputs markdown format", () => {
+    const result = runScript(["--format", "markdown"]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.startsWith("**テスト** (_")).toBe(true);
+    expect(result.stdout).toContain("- タグ: DX, SAP");
+  });
+
+  test("outputs json format with filters", () => {
+    const result = runScript(["--format", "json"]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const payload = JSON.parse(result.stdout);
+    expect(payload.title).toBe("テスト");
+    expect(payload.filters.manager).toBe("Yamada");
+    expect(payload.filters.tags).toEqual(["DX", "SAP"]);
+    expect(payload.notes).toBe("メモ");
+    expect(typeof payload.generatedAt).toBe("string");
+  });
+
+  test("returns error for unknown format", () => {
+    const result = runScript(["--format", "csv"]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Unknown format");
+  });
+});


### PR DESCRIPTION
## Summary
- scripts/project-share-slack.js を対象に Node/Vitest ベースのスモークテストを追加しました
- text / markdown / json の各出力を検証し、未知フォーマットのエラーも確認しています
- `npm run test:unit` に新テストを組み込み、`npm run test:share-cli` で単独実行もできるようにしました

## Testing
- npm run test:share-cli (ui-poc)
- npm run test:unit (ui-poc)
