### PR TITLE
Add project count support to share CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 `PROJECTS_URL` / `PROJECTS_TITLE` / `PROJECTS_NOTES` の各環境変数を上書きすることでサンプルスクリプトの出力を変更できます。
 
-`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。
+`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します。
 `--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します。
 
 GitHub Actions には週次スケジュール (`Projects Slack Share Check`) を追加し、サンプルメッセージの生成が失敗しないかを継続的に確認しています。

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -48,13 +48,16 @@ JSON 形式では Slack で利用するメッセージ文字列に加え、フ�
   "filters": {
     "status": "active",
     "manager": "Yamada",
-    "tags": ["DX", "SAP"]
+    "tags": ["DX", "SAP"],
+    "count": 24
   },
+  "projectCount": 24,
   "message": ":clipboard: *Weekly Projects Update* _(2025/10/11 6:30:00)_\n..."
 }
 ```
 
 この JSON をそのままワークフローへ渡すことで、Slack 以外の通知基盤にも再利用できます。
+`--count <number>` を指定すると、bullet / JSON の両方に対象件数 (`filters.count` / `projectCount`) が含まれるため、KPI 抜粋やダッシュボードとの照合にも活用できます。
 
 Slack への投稿を自動化したい場合は Incoming Webhook URL を `--post` に渡してください。メッセージ本文（text 形式）がそのまま送信されます。
 

--- a/ui-poc/tests/share-cli/project-share-slack.test.ts
+++ b/ui-poc/tests/share-cli/project-share-slack.test.ts
@@ -55,6 +55,13 @@ describe("project-share-slack CLI", () => {
     expect(result.stdout).toContain("• タグ: DX, SAP");
   });
 
+  test("includes count bullet when provided", () => {
+    const result = runScript(["--count", "17"]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("• 件数: 17");
+  });
+
   test("outputs markdown format", () => {
     const result = runScript(["--format", "markdown"]);
     expect(result.status).toBe(0);
@@ -63,8 +70,8 @@ describe("project-share-slack CLI", () => {
     expect(result.stdout).toContain("- タグ: DX, SAP");
   });
 
-  test("outputs json format with filters", () => {
-    const result = runScript(["--format", "json"]);
+  test("outputs json format with filters and count", () => {
+    const result = runScript(["--format", "json", "--count", "42"]);
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     const payload = JSON.parse(result.stdout);
@@ -73,6 +80,8 @@ describe("project-share-slack CLI", () => {
     expect(payload.filters.tags).toEqual(["DX", "SAP"]);
     expect(payload.notes).toBe("メモ");
     expect(typeof payload.generatedAt).toBe("string");
+    expect(payload.projectCount).toBe(42);
+    expect(payload.message).toContain("• 件数: 42");
   });
 
   test("returns error for unknown format", () => {
@@ -80,6 +89,13 @@ describe("project-share-slack CLI", () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("Unknown format");
+  });
+
+  test("returns error for invalid count", () => {
+    const result = runScript(["--count", "abc"]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Invalid count provided");
   });
 
   test("posts to webhook when --post provided", async () => {


### PR DESCRIPTION
## Summary
- share CLI に `--count` オプションを追加し、対象件数を bullet / JSON 出力に含められるようにしました
- `filters.count` と `projectCount` を JSON に追加し、ワークフロー側で KPI として再利用できます
- 無効な件数指定時にはエラーで終了し、vitest にカバレッジを追加しました
- README / ドキュメントを更新し、`--count` と `--post` の併用例を追記しました

## Testing
- npm run lint (ui-poc)
- npm run test:share-cli (ui-poc)
- npm run test:unit (ui-poc)
