### PR TITLE
Allow multiple webhook targets for share CLI

### DIFF
--- a/scripts/project-share-slack.js
+++ b/scripts/project-share-slack.js
@@ -47,6 +47,14 @@ for (let index = 0; index < args.length; index += 1) {
       console.error(`Option --${key} requires a value`);
       process.exit(1);
     }
+    if (key === 'post') {
+      if (!Array.isArray(options.post)) {
+        options.post = [];
+      }
+      options.post.push(next);
+      index += 1;
+      continue;
+    }
     options[key] = next;
     index += 1;
   } else if (token.startsWith('-')) {
@@ -63,6 +71,14 @@ for (let index = 0; index < args.length; index += 1) {
     if (!next || next.startsWith('-')) {
       console.error(`Option ${token} requires a value`);
       process.exit(1);
+    }
+    if (alias === 'post') {
+      if (!Array.isArray(options.post)) {
+        options.post = [];
+      }
+      options.post.push(next);
+      index += 1;
+      continue;
     }
     options[alias] = next;
     index += 1;
@@ -168,7 +184,12 @@ const message = [
 
 const format = (options.format ?? 'text').toLowerCase();
 const outPath = typeof options.out === 'string' ? options.out.trim() : '';
-const webhookUrl = typeof options.post === 'string' ? options.post.trim() : '';
+const rawWebhookOption = options.post;
+const webhookTargets = Array.isArray(rawWebhookOption)
+  ? rawWebhookOption.map((value) => String(value).trim()).filter(Boolean)
+  : rawWebhookOption
+    ? [String(rawWebhookOption).trim()].filter(Boolean)
+    : [];
 const filters = {
   status: params.has('status') ? status : 'all',
   keyword: keyword ?? '',
@@ -283,13 +304,13 @@ function postToWebhook(url, text) {
     }
   }
 
-  if (webhookUrl) {
-    if (!/^https?:\/\//i.test(webhookUrl)) {
-      console.error(`Invalid webhook URL: ${webhookUrl}`);
+  for (const target of webhookTargets) {
+    if (!/^https?:\/\//i.test(target)) {
+      console.error(`Invalid webhook URL: ${target}`);
       process.exit(1);
     }
-    await postToWebhook(webhookUrl, payload.message);
-    console.error('Posted share message to webhook');
+    await postToWebhook(target, payload.message);
+    console.error(`Posted share message to webhook: ${target}`);
   }
 })().catch((error) => {
   console.error(error instanceof Error ? error.message : error);

--- a/ui-poc/tests/share-cli/project-share-slack.test.ts
+++ b/ui-poc/tests/share-cli/project-share-slack.test.ts
@@ -114,8 +114,8 @@ describe("project-share-slack CLI", () => {
     expect(result.stderr).toContain("Invalid count provided");
   });
 
-  test("posts to webhook when --post provided", async () => {
-    const received: Array<{ text: string }> = [];
+  test("posts to one or more webhooks when --post provided", async () => {
+    const received: Array<{ text: string; path: string | undefined }> = [];
     await new Promise<void>((resolve, reject) => {
       const server = createServer((request, response) => {
         let body = "";
@@ -124,7 +124,8 @@ describe("project-share-slack CLI", () => {
         });
         request.on("end", () => {
           try {
-            received.push(JSON.parse(body));
+            const parsed = JSON.parse(body);
+            received.push({ text: parsed.text, path: request.url ?? undefined });
           } catch (error) {
             // ignore parse errors and let assertion fail later
           }
@@ -141,7 +142,8 @@ describe("project-share-slack CLI", () => {
           return;
         }
         const webhookUrl = `http://127.0.0.1:${address.port}/webhook`;
-        runScriptAsync(["--format", "json", "--post", webhookUrl])
+        const webhookUrlSecondary = `http://127.0.0.1:${address.port}/webhook-secondary`;
+        runScriptAsync(["--format", "json", "--post", webhookUrl, "--post", webhookUrlSecondary])
           .then((result) => {
             server.close((closeError) => {
               if (closeError) {
@@ -150,9 +152,14 @@ describe("project-share-slack CLI", () => {
               }
               try {
                 expect(result.status).toBe(0);
-                expect(received).toHaveLength(1);
+                expect(received).toHaveLength(2);
                 expect(received[0].text).toContain(":clipboard: *テスト*");
-                expect(result.stderr).toContain("Posted share message to webhook");
+                expect(received[1].text).toContain(":clipboard: *テスト*");
+                expect(new Set(received.map((entry) => entry.path))).toEqual(
+                  new Set(["/webhook", "/webhook-secondary"]),
+                );
+                expect(result.stderr).toContain(`Posted share message to webhook: ${webhookUrl}`);
+                expect(result.stderr).toContain(`Posted share message to webhook: ${webhookUrlSecondary}`);
                 resolve();
               } catch (assertionError) {
                 reject(assertionError);


### PR DESCRIPTION
## Summary
- `--post` オプションを複数回指定できるようにし、指定したすべての Slack Webhook へテンプレートを投稿するよう拡張しました
- CLI パーサーで `--post` を配列化し、同一実行内での複数送信とバリデーションをサポートします
- Vitest で 2 件の Webhook 呼び出しを検証するテストを追加しました

## Testing
- npm run test:share-cli (ui-poc)
- npm run test:unit (ui-poc)
