### PR TITLE
Add retry support to share CLI webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 `PROJECTS_URL` / `PROJECTS_TITLE` / `PROJECTS_NOTES` の各環境変数を上書きすることでサンプルスクリプトの出力を変更できます。
 
-`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。`--ensure-ok` を付けると、Webhook の応答本文が `ok` でない場合にエラー終了します。
+`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` を指定すると失敗時に再送できます。
 
 GitHub Actions には週次スケジュール (`Projects Slack Share Check`) を追加し、サンプルメッセージの生成が失敗しないかを継続的に確認しています。
 

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -68,7 +68,7 @@ node scripts/project-share-slack.js \
   --post 'https://hooks.slack.com/services/XXX/YYY/ZZZ'
 ```
 
-Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI でも失敗を検知できます。Slack Webhook の応答本文が `ok` になることを保証したい場合は `--ensure-ok` を併用してください。
+Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI でも失敗を検知できます。Slack Webhook の応答本文が `ok` になることを保証したい場合は `--ensure-ok` を併用してください。ネットワーク揺らぎへの耐性を持たせたい場合は `--retry 3 --retry-delay 2000` のように再送回数と待機ミリ秒を指定できます。
 
 ## 設定ファイルの利用
 繰り返し利用する設定は JSON ファイルにまとめておくのがおすすめです。`--config <path>` を指定すると、ファイル内の値を既定値として読み込み、CLI 引数で上書きできます。
@@ -80,6 +80,9 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
   "notes": "Config から読み込んだメモ",
   "format": "json",
   "count": 12,
+  "retry": 2,
+  "retryDelay": 1500,
+  "ensure-ok": true,
   "post": ["https://hooks.slack.com/services/AAA/BBB/CCC"]
 }
 ```
@@ -88,7 +91,7 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
 node scripts/project-share-slack.js --config share.config.json
 ```
 
-`post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。
+`post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。`ensure-ok` / `retry` / `retry-delay` も同様に設定ファイルで既定値を定義できます。
 
 ## CI への組み込み例
 `.github/workflows/projects-share-template.yml` では CLI を定期実行して体裁崩れを検知しています。JSON 出力を検証する際は `jq` で値をチェックすると安全です。


### PR DESCRIPTION
## Summary
- share CLI に `--retry` / `--retry-delay` オプションを追加し、Slack Webhook 送信の再試行が行えるようにしました
- 既定で 0 回リトライ、`--retry` で回数、`--retry-delay` で待機ミリ秒を指定できます（設定ファイルからも指定可能）
- 再試行ロジックを追加し、成功・失敗のケースを網羅するユニットテストとドキュメント更新を行いました

## Testing
- npm run test:share-cli (ui-poc)
- npm run test:unit (ui-poc)
