### PR TITLE
Add template support for share CLI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 `--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` / `--retry-backoff <value>` / `--retry-max-delay <ms>` / `--retry-jitter <ms>` を指定すると失敗時の再送挙動を細かく制御できます。
 
+config に `templates` を定義しておくと、`--template <name>` で共通プリセットを呼び出しつつ CLI 引数で上書きできます。
+
 GitHub Actions には週次スケジュール (`Projects Slack Share Check`) を追加し、サンプルメッセージの生成が失敗しないかを継続的に確認しています。
 
 ## 📝 ライセンス

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -97,6 +97,8 @@ node scripts/project-share-slack.js --config share.config.json
 
 `post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。`ensure-ok` / `retry` / `retry-delay` も同様に設定ファイルで既定値を定義できます。
 
+テンプレートを定義した場合は `--template <name>` で呼び出せます。テンプレート内で指定した値は CLI 引数よりも前に適用されるため、雛形を決めてから一部のみ上書きできます。
+
 ## CI への組み込み例
 `.github/workflows/projects-share-template.yml` では CLI を定期実行して体裁崩れを検知しています。JSON 出力を検証する際は `jq` で値をチェックすると安全です。
 

--- a/ui-poc/tests/share-cli/project-share-slack.test.ts
+++ b/ui-poc/tests/share-cli/project-share-slack.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createServer } from "node:http";
@@ -18,6 +18,11 @@ const baseArgs = [
 
 const runScript = (extraArgs: string[] = []) =>
   spawnSync(process.execPath, [scriptPath, ...baseArgs, ...extraArgs], {
+    encoding: "utf-8",
+  });
+
+const runScriptRaw = (args: string[] = []) =>
+  spawnSync(process.execPath, [scriptPath, ...args], {
     encoding: "utf-8",
   });
 
@@ -161,6 +166,94 @@ describe("project-share-slack CLI", () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("Invalid retry-jitter value");
+  });
+
+  test("load defaults from config", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "share-cli-config-"));
+    try {
+      const configPath = path.join(tempDir, "config.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            url: "https://example.com/projects?status=planned&manager=Suzuki",
+            title: "Config Title",
+            notes: "Config Notes",
+            format: "json",
+            count: 7,
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = runScriptRaw(["--config", configPath]);
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout);
+      validateSharePayload(payload);
+      expect(payload.title).toBe("Config Title");
+      expect(payload.notes).toBe("Config Notes");
+      expect(payload.filters.status).toBe("planned");
+      expect(payload.filters.manager).toBe("Suzuki");
+      expect(payload.projectCount).toBe(7);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("loads template defaults from config", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "share-cli-template-"));
+    try {
+      const configPath = path.join(tempDir, "config.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            templates: {
+              daily: {
+                title: "Daily Template",
+                notes: "Template notes",
+                format: "json",
+                count: 3,
+              },
+            },
+            url: "https://example.com/projects?status=planned",
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = runScriptRaw(["--config", configPath, "--template", "daily"]);
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout);
+      expect(payload.title).toBe("Daily Template");
+      expect(payload.notes).toBe("Template notes");
+      expect(payload.filters.status).toBe("planned");
+      expect(payload.projectCount).toBe(3);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails when template name is unknown", () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "share-cli-template-missing-"));
+    try {
+      const configPath = path.join(tempDir, "config.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify({ templates: { daily: { title: "Daily" } } }, null, 2),
+        "utf-8",
+      );
+
+      const result = runScriptRaw(["--config", configPath, "--template", "weekly"]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Unknown template: weekly");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("posts to one or more webhooks when --post provided", async () => {


### PR DESCRIPTION
## Summary
- share CLI に `--template` / `-T` オプションを追加し、config の `templates` セクションからプリセットを適用できるようにしました
- テンプレート→設定ファイル→CLI 引数の順でマージし、post/ensure-ok/retry 系の値も自動補完されます
- 設定ファイルのテンプレ利用とエラーハンドリングのユニットテスト、およびドキュメント更新を行いました

## Testing
- npm run test:share-cli (ui-poc)
- npm run test:unit (ui-poc)
