### PR TITLE
Add optional Retry-After handling to share CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 `PROJECTS_URL` / `PROJECTS_TITLE` / `PROJECTS_NOTES` の各環境変数を上書きすることでサンプルスクリプトの出力を変更できます。
 
-`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` / `--retry-backoff <value>` / `--retry-max-delay <ms>` / `--retry-jitter <ms>` を指定すると失敗時の再送挙動を細かく制御できます。
+`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` / `--retry-backoff <value>` / `--retry-max-delay <ms>` / `--retry-jitter <ms>` / `--respect-retry-after` を指定すると失敗時の再送挙動を細かく制御できます。
 
 config に `templates` を定義すると、`--template <name>` で共通プリセットを呼び出しつつ CLI 引数で部分的に上書きできます。`--audit-log <path>` を指定すると Webhook 投稿の成功／失敗履歴を JSON で保存します。
 

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -73,6 +73,7 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
 - `--retry-backoff` で遅延時間に乗算する係数（既定 2）を調整できます。
 - `--retry-max-delay` で遅延時間の上限をミリ秒単位で指定できます（既定 60000）。
 - `--retry-jitter` で各再試行に加算する 0〜指定値ミリ秒のジッタを追加できます。
+- `--respect-retry-after` を付けると、Slack から返される `Retry-After` ヘッダー（秒/日時）に応じて次回再試行までの待機時間を自動で延長します。
 
 ## 設定ファイルの利用
 繰り返し利用する設定は JSON ファイルにまとめておくのがおすすめです。`--config <path>` を指定すると、ファイル内の値を既定値として読み込み、CLI 引数で上書きできます。
@@ -95,7 +96,7 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
 node scripts/project-share-slack.js --config share.config.json
 ```
 
-`post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。`ensure-ok` / `retry` / `retry-delay` / `retry-backoff` / `retry-max-delay` / `retry-jitter` も同様に設定ファイルで既定値を定義できます。
+`post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。`ensure-ok` / `respect-retry-after` / `retry` / `retry-delay` / `retry-backoff` / `retry-max-delay` / `retry-jitter` も同様に設定ファイルで既定値を定義できます。
 
 `templates` にプリセットを定義すると、`--template <name>` で適用できます。テンプレートで指定した値は CLI 引数に先立って設定されるため、雛形を用意した上で必要な部分だけ上書きするといった使い方ができます。
 

--- a/scripts/project-share-slack.js
+++ b/scripts/project-share-slack.js
@@ -33,6 +33,7 @@ const optionAliases = new Map([
   ['-p', 'post'],
   ['-C', 'config'],
   ['-E', 'ensure-ok'],
+  ['-R', 'respect-retry-after'],
   ['-r', 'retry'],
   ['-d', 'retry-delay'],
   ['-b', 'retry-backoff'],
@@ -53,6 +54,11 @@ for (let index = 0; index < args.length;) {
     }
     if (key === 'ensure-ok') {
       options['ensure-ok'] = true;
+      index += 1;
+      continue;
+    }
+    if (key === 'respect-retry-after') {
+      options['respect-retry-after'] = true;
       index += 1;
       continue;
     }
@@ -89,6 +95,11 @@ for (let index = 0; index < args.length;) {
     }
     if (alias === 'ensure-ok') {
       options['ensure-ok'] = true;
+      index += 1;
+      continue;
+    }
+    if (alias === 'respect-retry-after') {
+      options['respect-retry-after'] = true;
       index += 1;
       continue;
     }
@@ -139,6 +150,7 @@ Options:
   --retry-backoff <value> Optional. 再試行ごとの遅延乗数（既定: 2）。
   --retry-max-delay <ms> Optional. 再試行遅延の上限ミリ秒（既定: 60000）。
   --retry-jitter <ms> Optional. 再試行遅延に加算する最大ジッタ。
+  --respect-retry-after Optional. Webhook 応答の Retry-After ヘッダーがあれば待機時間に反映します。
   --help            このヘルプを表示します。
 `;
 
@@ -188,6 +200,11 @@ if (options['ensure-ok'] === undefined && configEnsureValue !== undefined) {
   options['ensure-ok'] = Boolean(configEnsureValue);
 }
 
+const configRespectRetryAfter = config['respect-retry-after'] ?? config.respectRetryAfter;
+if (options['respect-retry-after'] === undefined && configRespectRetryAfter !== undefined) {
+  options['respect-retry-after'] = Boolean(configRespectRetryAfter);
+}
+
 if (options['retry-delay'] === undefined && config.retryDelay !== undefined) {
   options['retry-delay'] = config.retryDelay;
 }
@@ -220,6 +237,7 @@ options['retry-backoff'] = options['retry-backoff'] !== undefined ? String(optio
 options['retry-max-delay'] = options['retry-max-delay'] !== undefined ? String(options['retry-max-delay']) : undefined;
 options['retry-jitter'] = options['retry-jitter'] !== undefined ? String(options['retry-jitter']) : undefined;
 options['audit-log'] = options['audit-log'] !== undefined ? String(options['audit-log']) : undefined;
+options['respect-retry-after'] = Boolean(options['respect-retry-after']);
 if (Array.isArray(options.post)) {
   options.post = options.post.map((value) => String(value).trim()).filter((value) => value.length > 0);
 }
@@ -442,6 +460,7 @@ function postToWebhook(url, text, ensureOkResponse) {
         response.on('end', () => {
           const responseBody = Buffer.concat(chunks).toString('utf-8');
           const statusCode = response.statusCode ?? null;
+          const retryAfterMs = parseRetryAfterMs(response.headers);
           if (statusCode && statusCode >= 200 && statusCode < 300) {
             if (ensureOkResponse) {
               const normalized = responseBody.trim().toLowerCase();
@@ -449,17 +468,19 @@ function postToWebhook(url, text, ensureOkResponse) {
                 const error = new Error(`Unexpected webhook response body: ${responseBody.trim() || '(empty)'}`);
                 error.statusCode = statusCode;
                 error.responseBody = responseBody;
+                error.retryAfterMs = retryAfterMs ?? null;
                 reject(error);
                 return;
               }
             }
-            resolve({ statusCode, responseBody });
+            resolve({ statusCode, responseBody, retryAfterMs });
           } else {
             const error = new Error(
               `Failed to post to webhook (${statusCode ?? 'unknown'}): ${responseBody}`,
             );
             error.statusCode = statusCode;
             error.responseBody = responseBody;
+            error.retryAfterMs = retryAfterMs ?? null;
             reject(error);
           }
         });
@@ -471,6 +492,7 @@ function postToWebhook(url, text, ensureOkResponse) {
     });
     request.on('error', (error) => {
       error.statusCode = null;
+      error.retryAfterMs = null;
       reject(error);
     });
 
@@ -481,7 +503,44 @@ function postToWebhook(url, text, ensureOkResponse) {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function postWithRetry(url, text, ensureOkResponse, retries, initialDelayMs, backoff, maxDelayMs, jitterMs, events) {
+function parseRetryAfterMs(headers) {
+  if (!headers) {
+    return null;
+  }
+  const candidate = headers['retry-after'];
+  const value = Array.isArray(candidate) ? candidate[0] : candidate;
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return null;
+  }
+  const asNumber = Number(trimmed);
+  if (Number.isFinite(asNumber) && asNumber >= 0) {
+    const numericMs = asNumber * 1000;
+    return numericMs >= 0 ? Math.floor(numericMs) : null;
+  }
+  const parsedDate = Date.parse(trimmed);
+  if (!Number.isNaN(parsedDate)) {
+    const diff = parsedDate - Date.now();
+    return diff > 0 ? Math.floor(diff) : 0;
+  }
+  return null;
+}
+
+async function postWithRetry(
+  url,
+  text,
+  ensureOkResponse,
+  retries,
+  initialDelayMs,
+  backoff,
+  maxDelayMs,
+  jitterMs,
+  events,
+  respectRetryAfter,
+) {
   const maxDelayBound = maxDelayMs > 0 ? maxDelayMs : Number.MAX_SAFE_INTEGER;
   let attempt = 0;
   let currentDelay = initialDelayMs;
@@ -498,12 +557,20 @@ async function postWithRetry(url, text, ensureOkResponse, retries, initialDelayM
         statusCode: result.statusCode,
         responseBody: result.responseBody,
         elapsedMs: Date.now() - attemptStartedAt,
+        retryAfterMs: result.retryAfterMs ?? null,
       });
       return;
     } catch (error) {
+      const retryAfterMs =
+        typeof error?.retryAfterMs === 'number' && Number.isFinite(error.retryAfterMs) && error.retryAfterMs >= 0
+          ? Math.floor(error.retryAfterMs)
+          : null;
       const boundedDelay = Math.max(0, Math.min(maxDelayBound, currentDelay));
       const jitter = jitterMs > 0 ? Math.floor(Math.random() * (jitterMs + 1)) : 0;
-      const waitMs = attempt >= retries ? 0 : Math.max(0, boundedDelay + jitter);
+      let waitMs = attempt >= retries ? 0 : Math.max(0, boundedDelay + jitter);
+      if (respectRetryAfter && attempt < retries && retryAfterMs !== null) {
+        waitMs = Math.max(waitMs, retryAfterMs);
+      }
       events?.push({
         timestamp: new Date().toISOString(),
         webhook: url,
@@ -514,6 +581,7 @@ async function postWithRetry(url, text, ensureOkResponse, retries, initialDelayM
         error: error instanceof Error ? error.message : String(error),
         elapsedMs: Date.now() - attemptStartedAt,
         nextDelayMs: waitMs > 0 ? waitMs : null,
+        retryAfterMs,
       });
       if (attempt >= retries) {
         throw error;
@@ -549,7 +617,18 @@ async function postWithRetry(url, text, ensureOkResponse, retries, initialDelayM
       console.error(`Invalid webhook URL: ${target}`);
       process.exit(1);
     }
-    await postWithRetry(target, payload.message, ensureOk, retryCount, retryDelayMs, retryBackoff, retryMaxDelayMs, retryJitterMs, auditEvents);
+    await postWithRetry(
+      target,
+      payload.message,
+      ensureOk,
+      retryCount,
+      retryDelayMs,
+      retryBackoff,
+      retryMaxDelayMs,
+      retryJitterMs,
+      auditEvents,
+      options['respect-retry-after'],
+    );
     console.error(`Posted share message to webhook: ${target}`);
   }
 


### PR DESCRIPTION
## Summary
- add --respect-retry-after flag that toggles Retry-After header support for webhook retries
- capture Retry-After values in audit log entries and respect them when scheduling retries
- document the option and cover it with new Vitest scenarios

## Testing
- npm run test:share-cli