### PR TITLE
Add Projects API metrics option to share CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 `PROJECTS_URL` / `PROJECTS_TITLE` / `PROJECTS_NOTES` の各環境変数を上書きすることでサンプルスクリプトの出力を変更できます。
 
-`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` / `--retry-backoff <value>` / `--retry-max-delay <ms>` / `--retry-jitter <ms>` / `--respect-retry-after` を指定すると失敗時の再送挙動を細かく制御できます。
+`--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` / `--retry-backoff <value>` / `--retry-max-delay <ms>` / `--retry-jitter <ms>` / `--respect-retry-after` を指定すると失敗時の再送挙動を細かく制御できます。`--fetch-metrics` を併用すると Projects API から KPI を取得し、JSON 出力やメッセージへ件数サマリを付与できます（`--projects-api-base` / `--projects-api-token` / `--projects-api-tenant` / `--projects-api-timeout` で接続情報を上書き可能）。
 
 config に `templates` を定義すると、`--template <name>` で共通プリセットを呼び出しつつ CLI 引数で部分的に上書きできます。`--audit-log <path>` を指定すると Webhook 投稿の成功／失敗履歴を JSON で保存します。
 

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -74,6 +74,7 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
 - `--retry-max-delay` で遅延時間の上限をミリ秒単位で指定できます（既定 60000）。
 - `--retry-jitter` で各再試行に加算する 0〜指定値ミリ秒のジッタを追加できます。
 - `--respect-retry-after` を付けると、Slack から返される `Retry-After` ヘッダー（秒/日時）に応じて次回再試行までの待機時間を自動で延長します。
+- `--fetch-metrics` を有効にすると、Projects API から集計指標（件数 / リスク件数 / 警戒件数）を取得して JSON 出力に含めます。API の接続情報は `--projects-api-base` / `--projects-api-token` / `--projects-api-tenant` / `--projects-api-timeout` で上書きできます。
 
 ## 設定ファイルの利用
 繰り返し利用する設定は JSON ファイルにまとめておくのがおすすめです。`--config <path>` を指定すると、ファイル内の値を既定値として読み込み、CLI 引数で上書きできます。
@@ -96,7 +97,23 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
 node scripts/project-share-slack.js --config share.config.json
 ```
 
-`post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。`ensure-ok` / `respect-retry-after` / `retry` / `retry-delay` / `retry-backoff` / `retry-max-delay` / `retry-jitter` も同様に設定ファイルで既定値を定義できます。
+`post` は文字列または配列を指定でき、CLI 側で `--post` を複数回指定した場合はすべての Webhook に送信されます。`ensure-ok` / `respect-retry-after` / `fetch-metrics` / `retry` / `retry-delay` / `retry-backoff` / `retry-max-delay` / `retry-jitter` も同様に設定ファイルで既定値を定義できます。
+
+Projects API の接続情報は `projectsApi` セクションで管理します。
+
+```json
+{
+  "projectsApi": {
+    "baseUrl": "https://api.example.com",
+    "token": "${PROJECTS_API_TOKEN}",
+    "tenant": "example",
+    "timeoutMs": 15000,
+    "fetchMetrics": true
+  }
+}
+```
+
+CLI から明示的に `--projects-api-base` などを渡さない場合、このセクションの値が既定として使われます。トークンやテナント ID は環境変数 `PROJECTS_API_TOKEN` / `PROJECTS_API_TENANT` からも読み取れるため、CI ではシークレットを環境変数として注入する運用が推奨です。
 
 `templates` にプリセットを定義すると、`--template <name>` で適用できます。テンプレートで指定した値は CLI 引数に先立って設定されるため、雛形を用意した上で必要な部分だけ上書きするといった使い方ができます。
 

--- a/scripts/project-share-slack.js
+++ b/scripts/project-share-slack.js
@@ -76,6 +76,11 @@ for (let index = 0; index < args.length;) {
       index += 2;
       continue;
     }
+    if (key === 'fetch-metrics') {
+      options['fetch-metrics'] = true;
+      index += 1;
+      continue;
+    }
     const next = args[index + 1];
     if (!next || next.startsWith('-')) {
       console.error(`Option --${key} requires a value`);
@@ -153,6 +158,11 @@ Options:
   --retry-max-delay <ms> Optional. 再試行遅延の上限ミリ秒（既定: 60000）。
   --retry-jitter <ms> Optional. 再試行遅延に加算する最大ジッタ。
   --respect-retry-after Optional. Webhook 応答の Retry-After ヘッダーがあれば待機時間に反映します。
+  --fetch-metrics   Optional. Projects API から KPI を取得し JSON 出力へ含めます。
+  --projects-api-base <url> Optional. Projects API のベース URL（省略時は共有リンクのオリジン）。
+  --projects-api-token <value> Optional. Projects API への Bearer トークン。
+  --projects-api-tenant <value> Optional. Projects API 呼び出し時の X-Tenant-ID。
+  --projects-api-timeout <ms> Optional. Projects API 呼び出しのタイムアウト（既定: 10000）。
   --help            このヘルプを表示します。
 `;
 
@@ -187,7 +197,25 @@ const applyDefaultsFromObject = (source) => {
   if (!source || typeof source !== 'object') {
     return;
   }
-  ['url', 'title', 'notes', 'format', 'count', 'out', 'retry', 'retry-delay', 'retry-backoff', 'retry-max-delay', 'retry-jitter', 'audit-log'].forEach((key) => {
+  [
+    'url',
+    'title',
+    'notes',
+    'format',
+    'count',
+    'out',
+    'retry',
+    'retry-delay',
+    'retry-backoff',
+    'retry-max-delay',
+    'retry-jitter',
+    'audit-log',
+    'fetch-metrics',
+    'projects-api-base',
+    'projects-api-token',
+    'projects-api-tenant',
+    'projects-api-timeout',
+  ].forEach((key) => {
     if (source[key] !== undefined && options[key] === undefined) {
       options[key] = source[key];
     }
@@ -222,7 +250,25 @@ if (templateName) {
   applyDefaultsFromObject(template);
 }
 
-['url', 'title', 'notes', 'format', 'count', 'out', 'retry', 'retry-delay', 'retry-backoff', 'retry-max-delay', 'retry-jitter', 'audit-log'].forEach(assignDefault);
+[
+  'url',
+  'title',
+  'notes',
+  'format',
+  'count',
+  'out',
+  'retry',
+  'retry-delay',
+  'retry-backoff',
+  'retry-max-delay',
+  'retry-jitter',
+  'audit-log',
+  'fetch-metrics',
+  'projects-api-base',
+  'projects-api-token',
+  'projects-api-tenant',
+  'projects-api-timeout',
+].forEach(assignDefault);
 
 if (config.post !== undefined) {
   const configPosts = Array.isArray(config.post) ? config.post : [config.post];
@@ -239,6 +285,26 @@ if (config.post !== undefined) {
 const configEnsureValue = config['ensure-ok'] ?? config.ensureOk;
 if (options['ensure-ok'] === undefined && configEnsureValue !== undefined) {
   options['ensure-ok'] = Boolean(configEnsureValue);
+}
+
+if (config.projectsApi && typeof config.projectsApi === 'object') {
+  const projectsApi = config.projectsApi;
+  if (options['projects-api-base'] === undefined && typeof projectsApi.baseUrl === 'string') {
+    options['projects-api-base'] = projectsApi.baseUrl;
+  }
+  if (options['projects-api-token'] === undefined && typeof projectsApi.token === 'string') {
+    options['projects-api-token'] = projectsApi.token;
+  }
+  if (options['projects-api-tenant'] === undefined && typeof projectsApi.tenant === 'string') {
+    options['projects-api-tenant'] = projectsApi.tenant;
+  }
+  const timeoutCandidate = projectsApi.timeoutMs ?? projectsApi.timeout;
+  if (options['projects-api-timeout'] === undefined && timeoutCandidate !== undefined) {
+    options['projects-api-timeout'] = timeoutCandidate;
+  }
+  if (options['fetch-metrics'] === undefined && typeof projectsApi.fetchMetrics === 'boolean') {
+    options['fetch-metrics'] = projectsApi.fetchMetrics;
+  }
 }
 
 const configRespectRetryAfter = config['respect-retry-after'] ?? config.respectRetryAfter;
@@ -278,7 +344,29 @@ options['retry-backoff'] = options['retry-backoff'] !== undefined ? String(optio
 options['retry-max-delay'] = options['retry-max-delay'] !== undefined ? String(options['retry-max-delay']) : undefined;
 options['retry-jitter'] = options['retry-jitter'] !== undefined ? String(options['retry-jitter']) : undefined;
 options['audit-log'] = options['audit-log'] !== undefined ? String(options['audit-log']) : undefined;
+options['projects-api-base'] = options['projects-api-base'] !== undefined ? String(options['projects-api-base']) : undefined;
+options['projects-api-token'] = options['projects-api-token'] !== undefined ? String(options['projects-api-token']) : undefined;
+options['projects-api-tenant'] = options['projects-api-tenant'] !== undefined ? String(options['projects-api-tenant']) : undefined;
+options['projects-api-timeout'] = options['projects-api-timeout'] !== undefined ? String(options['projects-api-timeout']) : undefined;
+if (options['projects-api-base'] === undefined && typeof process.env.PROJECTS_API_BASE === 'string') {
+  options['projects-api-base'] = process.env.PROJECTS_API_BASE;
+}
+if (options['projects-api-token'] === undefined && typeof process.env.PROJECTS_API_TOKEN === 'string') {
+  options['projects-api-token'] = process.env.PROJECTS_API_TOKEN;
+}
+if (options['projects-api-tenant'] === undefined && typeof process.env.PROJECTS_API_TENANT === 'string') {
+  options['projects-api-tenant'] = process.env.PROJECTS_API_TENANT;
+}
+if (options['projects-api-timeout'] === undefined && typeof process.env.PROJECTS_API_TIMEOUT === 'string') {
+  options['projects-api-timeout'] = process.env.PROJECTS_API_TIMEOUT;
+}
 options['respect-retry-after'] = Boolean(options['respect-retry-after']);
+if (typeof options['fetch-metrics'] === 'string') {
+  const normalizedFetchValue = options['fetch-metrics'].trim().toLowerCase();
+  options['fetch-metrics'] = ['1', 'true', 'yes', 'on'].includes(normalizedFetchValue);
+} else {
+  options['fetch-metrics'] = Boolean(options['fetch-metrics']);
+}
 if (Array.isArray(options.post)) {
   options.post = options.post.map((value) => String(value).trim()).filter((value) => value.length > 0);
 }
@@ -337,6 +425,16 @@ if (options['retry-jitter'] !== undefined) {
 
 if (retryDelayMs > retryMaxDelayMs && retryMaxDelayMs > 0) {
   retryDelayMs = retryMaxDelayMs;
+}
+
+let projectsApiTimeoutMs = 10000;
+if (options['projects-api-timeout'] !== undefined) {
+  const parsedTimeout = Number(options['projects-api-timeout']);
+  if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) {
+    console.error(`Invalid projects-api-timeout value: ${options['projects-api-timeout']}`);
+    process.exit(1);
+  }
+  projectsApiTimeoutMs = Math.floor(parsedTimeout);
 }
 
 let parsedUrl;
@@ -408,13 +506,6 @@ const title = options.title ?? 'Projects 共有リンク';
 const generatedAt = new Date();
 const timestamp = generatedAt.toLocaleString('ja-JP', { hour12: false, timeZone: 'Asia/Tokyo' });
 
-const message = [
-  `:clipboard: *${title}* _(${timestamp})_`,
-  parsedUrl.toString(),
-  '',
-  ...bulletLines,
-].join('\n');
-
 const format = (options.format ?? 'text').toLowerCase();
 const outPath = typeof options.out === 'string' ? options.out.trim() : '';
 const webhookTargets = Array.isArray(options.post)
@@ -432,40 +523,40 @@ const filters = {
   count: projectCount,
 };
 
-const markdown = [
-  `**${title}** (_${timestamp}_)`,
-  parsedUrl.toString(),
-  '',
-  ...bulletLines.map((line) => line.replace(/^• /, '- ')),
-].join('\n');
+const buildShareOutputs = (lines, metrics) => {
+  const normalizedLines = Array.isArray(lines) ? lines : [];
+  const message = [
+    `:clipboard: *${title}* _(${timestamp})_`,
+    parsedUrl.toString(),
+    '',
+    ...normalizedLines,
+  ].join('\n');
 
-const payload = {
-  title,
-  url: parsedUrl.toString(),
-  generatedAt: generatedAt.toISOString(),
-  filters,
-  notes: trimmedNotes,
-  message,
-  projectCount,
+  const markdown = [
+    `**${title}** (_${timestamp}_)`,
+    parsedUrl.toString(),
+    '',
+    ...normalizedLines.map((line) => line.replace(/^• /, '- ')),
+  ].join('\n');
+
+  const payload = {
+    title,
+    url: parsedUrl.toString(),
+    generatedAt: generatedAt.toISOString(),
+    filters,
+    notes: trimmedNotes,
+    message,
+    projectCount,
+  };
+
+  if (metrics && typeof metrics === 'object') {
+    payload.metrics = metrics;
+  }
+
+  const jsonOutput = JSON.stringify(payload, null, 2);
+
+  return { message, markdown, jsonOutput, payload };
 };
-
-const jsonOutput = JSON.stringify(payload, null, 2);
-
-const allowedFormats = new Set(['text', 'markdown', 'json']);
-if (!allowedFormats.has(format)) {
-  console.error(`Unknown format: ${format}. Use text | markdown | json.`);
-  process.exit(1);
-}
-
-let renderedOutput = '';
-
-if (format === 'markdown') {
-  renderedOutput = markdown;
-} else if (format === 'json') {
-  renderedOutput = jsonOutput;
-} else {
-  renderedOutput = message;
-}
 
 function postToWebhook(url, text, ensureOkResponse) {
   const target = new URL(url);
@@ -570,6 +661,138 @@ function parseRetryAfterMs(headers) {
   return null;
 }
 
+async function fetchShareMetrics({ baseUrl, token, tenant, timeoutMs }) {
+  const resolvedBase = baseUrl ? baseUrl.trim() : '';
+  const apiBaseUrl = resolvedBase.length > 0 ? resolvedBase : parsedUrl.origin;
+  let apiBase;
+  try {
+    apiBase = new URL(apiBaseUrl);
+  } catch (error) {
+    throw new Error(`Invalid projects API base URL: ${apiBaseUrl}`);
+  }
+
+  const forwardKeys = ['status', 'keyword', 'manager', 'tag', 'tags', 'health'];
+  const buildSearchParams = (overrides = {}) => {
+    const search = new URLSearchParams();
+    for (const key of forwardKeys) {
+      const values = parsedUrl.searchParams.getAll(key);
+      if (values.length === 0) {
+        continue;
+      }
+      if (values.length === 1) {
+        const value = values[0]?.trim();
+        if (value) {
+          search.set(key, value);
+        }
+      } else {
+        values
+          .map((value) => value?.trim())
+          .filter((value) => value && value.length > 0)
+          .forEach((value) => {
+            search.append(key, value);
+          });
+      }
+    }
+
+    for (const [key, value] of Object.entries(overrides)) {
+      if (value === null || value === undefined || value === '') {
+        search.delete(key);
+      } else {
+        search.set(key, String(value));
+      }
+    }
+
+    if (!search.has('first')) {
+      search.set('first', '1');
+    }
+
+    return search;
+  };
+
+  const headers = {
+    Accept: 'application/json',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  if (tenant) {
+    headers['X-Tenant-ID'] = tenant;
+  }
+
+  const requestLog = [];
+  const executeRequest = async (label, overrides) => {
+    const url = new URL('/api/v1/projects', apiBase);
+    url.search = buildSearchParams(overrides).toString();
+    const controller = new AbortController();
+    const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
+    try {
+      const response = await fetch(url, {
+        headers,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`Projects API returned ${response.status}`);
+      }
+      const data = await response.json();
+      requestLog.push({
+        label,
+        url: url.toString(),
+        status: response.status,
+        total: data?.meta?.total ?? null,
+      });
+      return data;
+    } catch (error) {
+      if (error && typeof error === 'object' && error.name === 'AbortError') {
+        throw new Error(`Projects API request timed out after ${timeoutMs} ms (${url.toString()})`);
+      }
+      throw error;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  };
+
+  const totalsResponse = await executeRequest('total', {});
+  const totalProjects = Number(totalsResponse?.meta?.total ?? 0);
+
+  const riskResponse = await executeRequest('risk', { health: 'red' });
+  const riskProjects = Number(riskResponse?.meta?.total ?? 0);
+
+  const warningResponse = await executeRequest('warning', { health: 'yellow' });
+  const warningProjects = Number(warningResponse?.meta?.total ?? 0);
+
+  const metrics = {
+    fetchedAt: new Date().toISOString(),
+    apiBaseUrl: apiBase.origin,
+    totalProjects: Number.isFinite(totalProjects) ? totalProjects : null,
+    riskProjects: Number.isFinite(riskProjects) ? riskProjects : null,
+    warningProjects: Number.isFinite(warningProjects) ? warningProjects : null,
+    forwardedFilters: forwardKeys.reduce((accumulator, key) => {
+      const values = parsedUrl.searchParams.getAll(key);
+      if (values.length === 0) {
+        return accumulator;
+      }
+      accumulator[key] = values.length === 1 ? values[0] : values;
+      return accumulator;
+    }, {}),
+    requests: requestLog,
+  };
+
+  const metricLines = [];
+  if (metrics.totalProjects !== null) {
+    metricLines.push(`• API 件数: ${metrics.totalProjects}`);
+  }
+  if (metrics.riskProjects !== null) {
+    metricLines.push(`• リスク件数: ${metrics.riskProjects}`);
+  }
+  if (metrics.warningProjects !== null) {
+    metricLines.push(`• 警戒件数: ${metrics.warningProjects}`);
+  }
+
+  return { metrics, metricLines };
+}
+
 async function postWithRetry(
   url,
   text,
@@ -582,6 +805,7 @@ async function postWithRetry(
   events,
   respectRetryAfter,
 ) {
+
   const maxDelayBound = maxDelayMs > 0 ? maxDelayMs : Number.MAX_SAFE_INTEGER;
   let attempt = 0;
   let currentDelay = initialDelayMs;
@@ -642,6 +866,46 @@ async function postWithRetry(
 }
 
 (async () => {
+  let metricsResult = null;
+  if (options['fetch-metrics']) {
+    try {
+      metricsResult = await fetchShareMetrics({
+        baseUrl: options['projects-api-base'],
+        token: options['projects-api-token'],
+        tenant: options['projects-api-tenant'],
+        timeoutMs: projectsApiTimeoutMs,
+      });
+    } catch (error) {
+      console.error(`Failed to fetch metrics: ${error instanceof Error ? error.message : error}`);
+      process.exit(1);
+    }
+  }
+
+  const linesForOutput =
+    metricsResult && Array.isArray(metricsResult.metricLines) && metricsResult.metricLines.length > 0
+      ? [...bulletLines, ...metricsResult.metricLines]
+      : bulletLines;
+
+  const { message, markdown, jsonOutput, payload } = buildShareOutputs(
+    linesForOutput,
+    metricsResult ? metricsResult.metrics : undefined,
+  );
+
+  const allowedFormats = new Set(['text', 'markdown', 'json']);
+  if (!allowedFormats.has(format)) {
+    console.error(`Unknown format: ${format}. Use text | markdown | json.`);
+    process.exit(1);
+  }
+
+  let renderedOutput = '';
+  if (format === 'markdown') {
+    renderedOutput = markdown;
+  } else if (format === 'json') {
+    renderedOutput = jsonOutput;
+  } else {
+    renderedOutput = message;
+  }
+
   console.log(renderedOutput);
 
   if (outPath) {
@@ -681,6 +945,9 @@ async function postWithRetry(
         url: parsedUrl.toString(),
         attempts: auditEvents,
       };
+      if (metricsResult?.metrics) {
+        auditPayload.metrics = metricsResult.metrics;
+      }
       const directory = path.dirname(auditLogPath);
       if (directory && directory !== '.') {
         fs.mkdirSync(directory, { recursive: true });


### PR DESCRIPTION
## Summary
- add `--fetch-metrics` flag to query Projects API and append KPI details to share CLI outputs
- allow metrics defaults via `projectsApi` config section and surface values in audit logs
- cover the new behaviour with vitest, including mocked API responses

## Testing
- npm run test:share-cli
