### PR TITLE
Share CLI and UI use shared template builder

### DIFF
--- a/scripts/project-share-slack.js
+++ b/scripts/project-share-slack.js
@@ -20,6 +20,7 @@ const fs = require('node:fs');
 const http = require('node:http');
 const https = require('node:https');
 const path = require('node:path');
+const { buildShareTemplate } = require('../shared/cjs/share-template');
 
 const args = process.argv.slice(2);
 
@@ -463,6 +464,9 @@ const health = params.get('health');
 
 const trimmedNotes = options.notes?.trim() ?? '';
 const tagList = [tag?.trim(), ...(tags ? tags.split(',').map((value) => value.trim()) : [])].filter(Boolean);
+const trimmedKeyword = keyword?.trim() ?? '';
+const trimmedManager = manager?.trim() ?? '';
+const trimmedHealth = health?.trim() ?? '';
 
 let projectCount = null;
 if (typeof options.count !== 'undefined') {
@@ -474,37 +478,7 @@ if (typeof options.count !== 'undefined') {
   projectCount = Math.floor(parsedCount);
 }
 
-const bulletLines = [];
-
-if (params.has('status') && status !== 'all') {
-  const label = statusLabels.get(status) ?? status;
-  bulletLines.push(`• ステータス: *${label}*`);
-}
-if (projectCount !== null) {
-  bulletLines.push(`• 件数: ${projectCount}`);
-}
-if (keyword) {
-  bulletLines.push(`• キーワード: \`${keyword}\``);
-}
-if (manager) {
-  bulletLines.push(`• マネージャ: ${manager}`);
-}
-if (health) {
-  bulletLines.push(`• ヘルス: ${health}`);
-}
-if (tagList.length > 0) {
-  bulletLines.push(`• タグ: ${tagList.join(', ')}`);
-}
-if (trimmedNotes) {
-  bulletLines.push(`• メモ: ${trimmedNotes}`);
-}
-if (bulletLines.length === 0) {
-  bulletLines.push('• フィルタ: 指定なし');
-}
-
-const title = options.title ?? 'Projects 共有リンク';
 const generatedAt = new Date();
-const timestamp = generatedAt.toLocaleString('ja-JP', { hour12: false, timeZone: 'Asia/Tokyo' });
 
 const format = (options.format ?? 'text').toLowerCase();
 const outPath = typeof options.out === 'string' ? options.out.trim() : '';
@@ -514,48 +488,14 @@ const webhookTargets = Array.isArray(options.post)
 const ensureOk = Boolean(options['ensure-ok']);
 const auditLogPath = typeof options['audit-log'] === 'string' ? options['audit-log'].trim() : '';
 const auditEvents = auditLogPath ? [] : null;
-const filters = {
+const shareFilters = {
   status: params.has('status') ? status : 'all',
-  keyword: keyword ?? '',
-  manager: manager ?? '',
-  health: health ?? '',
+  statusLabel: statusLabels.get(status) ?? status,
+  keyword: trimmedKeyword,
+  manager: trimmedManager,
+  health: trimmedHealth,
   tags: tagList,
   count: projectCount,
-};
-
-const buildShareOutputs = (lines, metrics) => {
-  const normalizedLines = Array.isArray(lines) ? lines : [];
-  const message = [
-    `:clipboard: *${title}* _(${timestamp})_`,
-    parsedUrl.toString(),
-    '',
-    ...normalizedLines,
-  ].join('\n');
-
-  const markdown = [
-    `**${title}** (_${timestamp}_)`,
-    parsedUrl.toString(),
-    '',
-    ...normalizedLines.map((line) => line.replace(/^• /, '- ')),
-  ].join('\n');
-
-  const payload = {
-    title,
-    url: parsedUrl.toString(),
-    generatedAt: generatedAt.toISOString(),
-    filters,
-    notes: trimmedNotes,
-    message,
-    projectCount,
-  };
-
-  if (metrics && typeof metrics === 'object') {
-    payload.metrics = metrics;
-  }
-
-  const jsonOutput = JSON.stringify(payload, null, 2);
-
-  return { message, markdown, jsonOutput, payload };
 };
 
 function postToWebhook(url, text, ensureOkResponse) {
@@ -779,18 +719,7 @@ async function fetchShareMetrics({ baseUrl, token, tenant, timeoutMs }) {
     requests: requestLog,
   };
 
-  const metricLines = [];
-  if (metrics.totalProjects !== null) {
-    metricLines.push(`• API 件数: ${metrics.totalProjects}`);
-  }
-  if (metrics.riskProjects !== null) {
-    metricLines.push(`• リスク件数: ${metrics.riskProjects}`);
-  }
-  if (metrics.warningProjects !== null) {
-    metricLines.push(`• 警戒件数: ${metrics.warningProjects}`);
-  }
-
-  return { metrics, metricLines };
+  return metrics;
 }
 
 async function postWithRetry(
@@ -866,10 +795,10 @@ async function postWithRetry(
 }
 
 (async () => {
-  let metricsResult = null;
+  let metricsPayload = null;
   if (options['fetch-metrics']) {
     try {
-      metricsResult = await fetchShareMetrics({
+      metricsPayload = await fetchShareMetrics({
         baseUrl: options['projects-api-base'],
         token: options['projects-api-token'],
         tenant: options['projects-api-tenant'],
@@ -881,15 +810,21 @@ async function postWithRetry(
     }
   }
 
-  const linesForOutput =
-    metricsResult && Array.isArray(metricsResult.metricLines) && metricsResult.metricLines.length > 0
-      ? [...bulletLines, ...metricsResult.metricLines]
-      : bulletLines;
-
-  const { message, markdown, jsonOutput, payload } = buildShareOutputs(
-    linesForOutput,
-    metricsResult ? metricsResult.metrics : undefined,
-  );
+  let shareTemplate;
+  try {
+    shareTemplate = buildShareTemplate({
+      title: options.title,
+      url: parsedUrl.toString(),
+      notes: trimmedNotes,
+      filters: shareFilters,
+      generatedAt,
+      timezone: 'Asia/Tokyo',
+      metrics: metricsPayload ?? undefined,
+    });
+  } catch (error) {
+    console.error(`Failed to build share template: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
 
   const allowedFormats = new Set(['text', 'markdown', 'json']);
   if (!allowedFormats.has(format)) {
@@ -899,11 +834,11 @@ async function postWithRetry(
 
   let renderedOutput = '';
   if (format === 'markdown') {
-    renderedOutput = markdown;
+    renderedOutput = shareTemplate.markdown;
   } else if (format === 'json') {
-    renderedOutput = jsonOutput;
+    renderedOutput = shareTemplate.json;
   } else {
-    renderedOutput = message;
+    renderedOutput = shareTemplate.text;
   }
 
   console.log(renderedOutput);
@@ -924,7 +859,7 @@ async function postWithRetry(
     }
     await postWithRetry(
       target,
-      payload.message,
+      shareTemplate.payload.message,
       ensureOk,
       retryCount,
       retryDelayMs,
@@ -941,12 +876,12 @@ async function postWithRetry(
     try {
       const auditPayload = {
         generatedAt: new Date().toISOString(),
-        title,
-        url: parsedUrl.toString(),
+        title: shareTemplate.payload.title,
+        url: shareTemplate.payload.url,
         attempts: auditEvents,
       };
-      if (metricsResult?.metrics) {
-        auditPayload.metrics = metricsResult.metrics;
+      if (metricsPayload) {
+        auditPayload.metrics = metricsPayload;
       }
       const directory = path.dirname(auditLogPath);
       if (directory && directory !== '.') {

--- a/shared/cjs/share-template.d.ts
+++ b/shared/cjs/share-template.d.ts
@@ -1,0 +1,52 @@
+export interface ShareTemplateFilters {
+    status: string;
+    statusLabel?: string;
+    keyword?: string;
+    manager?: string;
+    health?: string;
+    tags?: ReadonlyArray<string>;
+    count?: number | null | undefined;
+}
+export interface ShareTemplateMetrics {
+    totalProjects?: number | null;
+    riskProjects?: number | null;
+    warningProjects?: number | null;
+    [key: string]: unknown;
+}
+export interface ShareTemplateOptions {
+    title?: string | null;
+    url: string;
+    notes?: string | null;
+    filters: ShareTemplateFilters;
+    generatedAt?: Date;
+    timezone?: string;
+    includeFilterFallback?: boolean;
+    metrics?: ShareTemplateMetrics | null;
+    formatTimestamp?: (date: Date) => string;
+}
+export interface ShareTemplatePayload {
+    title: string;
+    url: string;
+    generatedAt: string;
+    filters: {
+        status: string;
+        statusLabel?: string;
+        keyword: string;
+        manager: string;
+        health: string;
+        tags: string[];
+        count?: number | null;
+    };
+    notes: string;
+    message: string;
+    projectCount: number | null;
+    metrics?: ShareTemplateMetrics;
+}
+export interface ShareTemplateResult {
+    text: string;
+    markdown: string;
+    json: string;
+    payload: ShareTemplatePayload;
+    bulletLines: string[];
+}
+export declare function buildShareTemplate(options: ShareTemplateOptions): ShareTemplateResult;

--- a/shared/cjs/share-template.js
+++ b/shared/cjs/share-template.js
@@ -1,0 +1,134 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildShareTemplate = void 0;
+const isFiniteNumber = (value) => typeof value === "number" && Number.isFinite(value);
+const normalizeMetricValue = (value) => {
+    if (isFiniteNumber(value)) {
+        return Math.trunc(value);
+    }
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+        return Math.trunc(parsed);
+    }
+    return null;
+};
+const defaultTimestampFormatter = (date, timezone) => date.toLocaleString("ja-JP", { hour12: false, timeZone: timezone !== null && timezone !== void 0 ? timezone : "Asia/Tokyo" });
+function buildShareTemplate(options) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+    if (!options || typeof options.url !== "string" || options.url.trim().length === 0) {
+        throw new Error("buildShareTemplate requires a valid url");
+    }
+    const generatedAt = (_a = options.generatedAt) !== null && _a !== void 0 ? _a : new Date();
+    const formatTimestamp = typeof options.formatTimestamp === "function"
+        ? options.formatTimestamp
+        : (date) => defaultTimestampFormatter(date, options.timezone);
+    const filters = (_b = options.filters) !== null && _b !== void 0 ? _b : {};
+    const trimmedKeyword = ((_c = filters.keyword) !== null && _c !== void 0 ? _c : "").trim();
+    const trimmedManager = ((_d = filters.manager) !== null && _d !== void 0 ? _d : "").trim();
+    const trimmedHealth = ((_e = filters.health) !== null && _e !== void 0 ? _e : "").trim();
+    const tagValues = Array.isArray(filters.tags)
+        ? filters.tags.map((value) => value === null || value === void 0 ? void 0 : value.trim()).filter((value) => !!value)
+        : [];
+    const sanitizedCount = isFiniteNumber(filters.count) ? Math.trunc(filters.count) : null;
+    const rawNotes = (_f = options.notes) !== null && _f !== void 0 ? _f : "";
+    const trimmedNotes = rawNotes.trim();
+    const bulletLines = [];
+    const normalizedStatus = ((_g = filters.status) !== null && _g !== void 0 ? _g : "").trim();
+    if (normalizedStatus && normalizedStatus.toLowerCase() !== "all") {
+        const statusLabel = ((_h = filters.statusLabel) === null || _h === void 0 ? void 0 : _h.trim()) || normalizedStatus;
+        bulletLines.push(`• ステータス: *${statusLabel}*`);
+    }
+    if (sanitizedCount !== null) {
+        bulletLines.push(`• 件数: ${sanitizedCount}`);
+    }
+    if (trimmedKeyword.length > 0) {
+        bulletLines.push(`• キーワード: \`${trimmedKeyword}\``);
+    }
+    if (trimmedManager.length > 0) {
+        bulletLines.push(`• マネージャ: ${trimmedManager}`);
+    }
+    if (trimmedHealth.length > 0) {
+        bulletLines.push(`• ヘルス: ${trimmedHealth}`);
+    }
+    if (tagValues.length > 0) {
+        bulletLines.push(`• タグ: ${tagValues.join(", ")}`);
+    }
+    if (trimmedNotes.length > 0) {
+        bulletLines.push(`• メモ: ${trimmedNotes}`);
+    }
+    if (((_j = options.includeFilterFallback) !== null && _j !== void 0 ? _j : true) && bulletLines.length === 0) {
+        bulletLines.push("• フィルタ: 指定なし");
+    }
+    const rawMetrics = (_k = options.metrics) !== null && _k !== void 0 ? _k : undefined;
+    let sanitizedMetrics;
+    if (rawMetrics && typeof rawMetrics === "object") {
+        const total = normalizeMetricValue(rawMetrics.totalProjects);
+        const risk = normalizeMetricValue(rawMetrics.riskProjects);
+        const warning = normalizeMetricValue(rawMetrics.warningProjects);
+        if (total !== null) {
+            bulletLines.push(`• API 件数: ${total}`);
+        }
+        if (risk !== null) {
+            bulletLines.push(`• リスク件数: ${risk}`);
+        }
+        if (warning !== null) {
+            bulletLines.push(`• 警戒件数: ${warning}`);
+        }
+        sanitizedMetrics = { ...rawMetrics };
+        if (total !== null) {
+            sanitizedMetrics.totalProjects = total;
+        }
+        if (risk !== null) {
+            sanitizedMetrics.riskProjects = risk;
+        }
+        if (warning !== null) {
+            sanitizedMetrics.warningProjects = warning;
+        }
+    }
+    const effectiveTitle = typeof options.title === "string" && options.title.trim().length > 0
+        ? options.title.trim()
+        : "Projects 共有リンク";
+    const formattedTimestamp = formatTimestamp(generatedAt);
+    const messageLines = [
+        `:clipboard: *${effectiveTitle}* _(${formattedTimestamp})_`,
+        options.url,
+        "",
+        ...bulletLines,
+    ];
+    const text = messageLines.join("\n");
+    const markdown = [
+        `**${effectiveTitle}** (_${formattedTimestamp}_)`,
+        options.url,
+        "",
+        ...bulletLines.map((line) => line.replace(/^• /, "- ")),
+    ].join("\n");
+    const payload = {
+        title: effectiveTitle,
+        url: options.url,
+        generatedAt: generatedAt.toISOString(),
+        filters: {
+            status: normalizedStatus || "all",
+            statusLabel: filters.statusLabel,
+            keyword: trimmedKeyword,
+            manager: trimmedManager,
+            health: trimmedHealth,
+            tags: tagValues,
+            count: sanitizedCount,
+        },
+        notes: trimmedNotes,
+        message: text,
+        projectCount: sanitizedCount,
+    };
+    if (sanitizedMetrics) {
+        payload.metrics = sanitizedMetrics;
+    }
+    const json = JSON.stringify(payload, null, 2);
+    return {
+        text,
+        markdown,
+        json,
+        payload,
+        bulletLines,
+    };
+}
+exports.buildShareTemplate = buildShareTemplate;

--- a/shared/share-template.ts
+++ b/shared/share-template.ts
@@ -1,0 +1,200 @@
+export interface ShareTemplateFilters {
+  status: string;
+  statusLabel?: string;
+  keyword?: string;
+  manager?: string;
+  health?: string;
+  tags?: ReadonlyArray<string>;
+  count?: number | null | undefined;
+}
+
+export interface ShareTemplateMetrics {
+  totalProjects?: number | null;
+  riskProjects?: number | null;
+  warningProjects?: number | null;
+  [key: string]: unknown;
+}
+
+export interface ShareTemplateOptions {
+  title?: string | null;
+  url: string;
+  notes?: string | null;
+  filters: ShareTemplateFilters;
+  generatedAt?: Date;
+  timezone?: string;
+  includeFilterFallback?: boolean;
+  metrics?: ShareTemplateMetrics | null;
+  formatTimestamp?: (date: Date) => string;
+}
+
+export interface ShareTemplatePayload {
+  title: string;
+  url: string;
+  generatedAt: string;
+  filters: {
+    status: string;
+    statusLabel?: string;
+    keyword: string;
+    manager: string;
+    health: string;
+    tags: string[];
+    count?: number | null;
+  };
+  notes: string;
+  message: string;
+  projectCount: number | null;
+  metrics?: ShareTemplateMetrics;
+}
+
+export interface ShareTemplateResult {
+  text: string;
+  markdown: string;
+  json: string;
+  payload: ShareTemplatePayload;
+  bulletLines: string[];
+}
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const normalizeMetricValue = (value: unknown): number | null => {
+  if (isFiniteNumber(value)) {
+    return Math.trunc(value);
+  }
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return Math.trunc(parsed);
+  }
+  return null;
+};
+
+const defaultTimestampFormatter = (date: Date, timezone?: string): string =>
+  date.toLocaleString("ja-JP", { hour12: false, timeZone: timezone ?? "Asia/Tokyo" });
+
+export function buildShareTemplate(options: ShareTemplateOptions): ShareTemplateResult {
+  if (!options || typeof options.url !== "string" || options.url.trim().length === 0) {
+    throw new Error("buildShareTemplate requires a valid url");
+  }
+
+  const generatedAt = options.generatedAt ?? new Date();
+  const formatTimestamp =
+    typeof options.formatTimestamp === "function"
+      ? options.formatTimestamp
+      : (date: Date) => defaultTimestampFormatter(date, options.timezone);
+
+  const filters = options.filters ?? ({} as ShareTemplateFilters);
+  const trimmedKeyword = (filters.keyword ?? "").trim();
+  const trimmedManager = (filters.manager ?? "").trim();
+  const trimmedHealth = (filters.health ?? "").trim();
+  const tagValues = Array.isArray(filters.tags)
+    ? filters.tags.map((value) => value?.trim()).filter((value): value is string => !!value)
+    : [];
+  const sanitizedCount = isFiniteNumber(filters.count) ? Math.trunc(filters.count) : null;
+  const rawNotes = options.notes ?? "";
+  const trimmedNotes = rawNotes.trim();
+  const bulletLines: string[] = [];
+
+  const normalizedStatus = (filters.status ?? "").trim();
+  if (normalizedStatus && normalizedStatus.toLowerCase() !== "all") {
+    const statusLabel = filters.statusLabel?.trim() || normalizedStatus;
+    bulletLines.push(`• ステータス: *${statusLabel}*`);
+  }
+  if (sanitizedCount !== null) {
+    bulletLines.push(`• 件数: ${sanitizedCount}`);
+  }
+  if (trimmedKeyword.length > 0) {
+    bulletLines.push(`• キーワード: \`${trimmedKeyword}\``);
+  }
+  if (trimmedManager.length > 0) {
+    bulletLines.push(`• マネージャ: ${trimmedManager}`);
+  }
+  if (trimmedHealth.length > 0) {
+    bulletLines.push(`• ヘルス: ${trimmedHealth}`);
+  }
+  if (tagValues.length > 0) {
+    bulletLines.push(`• タグ: ${tagValues.join(", ")}`);
+  }
+  if (trimmedNotes.length > 0) {
+    bulletLines.push(`• メモ: ${trimmedNotes}`);
+  }
+  if ((options.includeFilterFallback ?? true) && bulletLines.length === 0) {
+    bulletLines.push("• フィルタ: 指定なし");
+  }
+
+  const rawMetrics = options.metrics ?? undefined;
+  let sanitizedMetrics: ShareTemplateMetrics | undefined;
+  if (rawMetrics && typeof rawMetrics === "object") {
+    const total = normalizeMetricValue((rawMetrics as Record<string, unknown>).totalProjects);
+    const risk = normalizeMetricValue((rawMetrics as Record<string, unknown>).riskProjects);
+    const warning = normalizeMetricValue((rawMetrics as Record<string, unknown>).warningProjects);
+    if (total !== null) {
+      bulletLines.push(`• API 件数: ${total}`);
+    }
+    if (risk !== null) {
+      bulletLines.push(`• リスク件数: ${risk}`);
+    }
+    if (warning !== null) {
+      bulletLines.push(`• 警戒件数: ${warning}`);
+    }
+    sanitizedMetrics = { ...rawMetrics };
+    if (total !== null) {
+      sanitizedMetrics.totalProjects = total;
+    }
+    if (risk !== null) {
+      sanitizedMetrics.riskProjects = risk;
+    }
+    if (warning !== null) {
+      sanitizedMetrics.warningProjects = warning;
+    }
+  }
+
+  const effectiveTitle =
+    typeof options.title === "string" && options.title.trim().length > 0
+      ? options.title.trim()
+      : "Projects 共有リンク";
+  const formattedTimestamp = formatTimestamp(generatedAt);
+  const messageLines = [
+    `:clipboard: *${effectiveTitle}* _(${formattedTimestamp})_`,
+    options.url,
+    "",
+    ...bulletLines,
+  ];
+  const text = messageLines.join("\n");
+  const markdown = [
+    `**${effectiveTitle}** (_${formattedTimestamp}_)`,
+    options.url,
+    "",
+    ...bulletLines.map((line) => line.replace(/^• /, "- ")),
+  ].join("\n");
+
+  const payload: ShareTemplatePayload = {
+    title: effectiveTitle,
+    url: options.url,
+    generatedAt: generatedAt.toISOString(),
+    filters: {
+      status: normalizedStatus || "all",
+      statusLabel: filters.statusLabel,
+      keyword: trimmedKeyword,
+      manager: trimmedManager,
+      health: trimmedHealth,
+      tags: tagValues,
+      count: sanitizedCount,
+    },
+    notes: trimmedNotes,
+    message: text,
+    projectCount: sanitizedCount,
+  };
+  if (sanitizedMetrics) {
+    payload.metrics = sanitizedMetrics;
+  }
+
+  const json = JSON.stringify(payload, null, 2);
+
+  return {
+    text,
+    markdown,
+    json,
+    payload,
+    bulletLines,
+  };
+}

--- a/ui-poc/next.config.mjs
+++ b/ui-poc/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  experimental: {
+    externalDir: true,
+  },
+};
 
 export default nextConfig;

--- a/ui-poc/tsconfig.json
+++ b/ui-poc/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../shared/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- introduce shared/share-template.ts to centralize Projects share message generation
- have the CLI consume the shared builder while the UI compose function reuses the module
- wire Next.js config and tsconfig so external shared code is available

## Testing
- npm run test:share-cli
