### PR TITLE
feat: per-webhook respect-retry-after override

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 `--format markdown` / `--format json` を指定すると、それぞれ Markdown 形式・JSON 形式で出力できます。`--count <number>` で対象件数を bullet に追加し、`--out <path>` で生成結果をファイル保存できます。`--post <webhook-url>` を併用すると Slack Incoming Webhook へメッセージを直接送信します（複数指定可）。`--config share.config.json` を指定すると、URL やタイトルなどの既定値を JSON ファイルから読み込めます。Slack 送信時には `--ensure-ok` で応答本文が `ok` か検証でき、`--retry <count>` / `--retry-delay <ms>` / `--retry-backoff <value>` / `--retry-max-delay <ms>` / `--retry-jitter <ms>` / `--respect-retry-after` を指定すると失敗時の再送挙動を細かく制御できます。`--fetch-metrics` を併用すると Projects API から KPI を取得し、JSON 出力やメッセージへ件数サマリを付与できます（`--projects-api-base` / `--projects-api-token` / `--projects-api-tenant` / `--projects-api-timeout` で接続情報を上書き可能）。
 
-config の `post` 配列にオブジェクトを定義すると、Webhook の URL ごとに `retry` / `retryDelay` / `retryBackoff` / `retryMaxDelay` / `retryJitter` / `ensure-ok` などを上書きでき、送信先ごとに異なるリトライ方針を適用できます。config に `templates` を定義すると、`--template <name>` で共通プリセットを呼び出しつつ CLI 引数で部分的に上書きできます。`--audit-log <path>` を指定すると Webhook 投稿の成功／失敗履歴を JSON で保存します。
+config の `post` 配列にオブジェクトを定義すると、Webhook の URL ごとに `retry` / `retryDelay` / `retryBackoff` / `retryMaxDelay` / `retryJitter` / `ensure-ok` / `respect-retry-after` などを上書きでき、送信先ごとに異なるリトライ方針を適用できます。config に `templates` を定義すると、`--template <name>` で共通プリセットを呼び出しつつ CLI 引数で部分的に上書きできます。`--audit-log <path>` を指定すると Webhook 投稿の成功／失敗履歴を JSON で保存します。
 
 テンプレートの管理には `--list-templates` で定義済みテンプレートを一覧表示し、`--remove-template <name>` で特定テンプレートを削除できます（どちらも `--config` 指定が必要です）。
 

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -127,13 +127,14 @@ Webhook ごとに異なるリトライ設定を適用したい場合は、`post`
       "retryBackoff": 1.5,
       "retryMaxDelay": 5000,
       "retryJitter": 250,
-      "ensure-ok": false
+      "ensure-ok": false,
+      "respectRetryAfter": true
     }
   ]
 }
 ```
 
-このように記述すると、特定の Webhook だけ異なる再送回数や遅延、`ensure-ok` の有無などを個別に設定できます。配列内では文字列 URL とオブジェクト設定を混在させることも可能です。
+このように記述すると、特定の Webhook だけ異なる再送回数や遅延、`ensure-ok` の有無、Retry-After ヘッダーの扱いなどを個別に設定できます。配列内では文字列 URL とオブジェクト設定を混在させることも可能です。
 
 `templates` にプリセットを定義すると、`--template <name>` で適用できます。テンプレートで指定した値は CLI 引数に先立って設定されるため、雛形を用意した上で必要な部分だけ上書きするといった使い方ができます。
 

--- a/scripts/project-share-slack.js
+++ b/scripts/project-share-slack.js
@@ -716,6 +716,12 @@ const webhookTargets = rawWebhookInputs
       if (retryJitterOverride !== undefined) {
         target.retryJitter = retryJitterOverride;
       }
+      const respectRetryAfterOverride = coerceBooleanOption(
+        entry['respect-retry-after'] ?? entry.respectRetryAfter,
+      );
+      if (respectRetryAfterOverride !== undefined) {
+        target.respectRetryAfter = respectRetryAfterOverride;
+      }
       return target;
     }
     const coerced = String(entry).trim();
@@ -726,6 +732,7 @@ const webhookTargets = rawWebhookInputs
   })
   .filter((entry) => entry && typeof entry.url === 'string' && entry.url.length > 0);
 const ensureOkDefault = Boolean(options['ensure-ok']);
+const respectRetryAfterDefault = Boolean(options['respect-retry-after']);
 const auditLogPath = typeof options['audit-log'] === 'string' ? options['audit-log'].trim() : '';
 const auditEvents = auditLogPath ? [] : null;
 const shareFilters = {
@@ -1104,6 +1111,8 @@ async function postWithRetry(
     const targetRetryBackoff = target.retryBackoff !== undefined ? target.retryBackoff : retryBackoff;
     let targetRetryMaxDelayMs = target.retryMaxDelay !== undefined ? target.retryMaxDelay : retryMaxDelayMs;
     const targetRetryJitterMs = target.retryJitter !== undefined ? target.retryJitter : retryJitterMs;
+    const targetRespectRetryAfter =
+      target.respectRetryAfter !== undefined ? target.respectRetryAfter : respectRetryAfterDefault;
 
     if (targetRetryDelayMs > targetRetryMaxDelayMs && targetRetryMaxDelayMs > 0) {
       console.warn(
@@ -1122,7 +1131,7 @@ async function postWithRetry(
       targetRetryMaxDelayMs,
       targetRetryJitterMs,
       auditEvents,
-      options['respect-retry-after'],
+      targetRespectRetryAfter,
     );
     console.error(`Posted share message to webhook: ${targetUrl}`);
   }


### PR DESCRIPTION
## Summary
- allow webhook entries to specify `respect-retry-after` overrides so rate limit hints can be honored selectively
- surface the override during target normalization and propagate it to the posting loop
- document the new JSON property and add a regression test covering Retry-After handling from config

## Testing
- npm run test:share-cli
