### PR TITLE
feat: enforce share CLI config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Projects 一覧の共有メッセージは以下の CLI で生成できます。
 
 config の `post` 配列にオブジェクトを定義すると、Webhook の URL ごとに `retry` / `retryDelay` / `retryBackoff` / `retryMaxDelay` / `retryJitter` / `ensure-ok` / `respect-retry-after` などを上書きでき、送信先ごとに異なるリトライ方針を適用できます。config に `templates` を定義すると、`--template <name>` で共通プリセットを呼び出しつつ CLI 引数で部分的に上書きできます。`--audit-log <path>` を指定すると Webhook 投稿の成功／失敗履歴を JSON で保存します。
 
+CLI は `--config` で読み込んだ設定を実行前に検証し、不正値が含まれている場合はエラーで終了します。CI などで事前確認したい場合は `--validate-config` を単体で実行すると検証結果と統計が表示されます。
+
 テンプレートの管理には `--list-templates` で定義済みテンプレートを一覧表示し、`--remove-template <name>` で特定テンプレートを削除できます（どちらも `--config` 指定が必要です）。
 
 GitHub Actions には週次スケジュール (`Projects Slack Share Check`) を追加し、サンプルメッセージの生成が失敗しないかを継続的に確認しています。

--- a/docs/projects-share-cli.md
+++ b/docs/projects-share-cli.md
@@ -78,6 +78,8 @@ Webhook 呼び出しに失敗すると終了コード 1 で落ちるため、CI 
 - `--fetch-metrics` を有効にすると、Projects API から集計指標（件数 / リスク件数 / 警戒件数）を取得して JSON 出力に含めます。API の接続情報は `--projects-api-base` / `--projects-api-token` / `--projects-api-tenant` / `--projects-api-timeout` で上書きできます。
 - `--validate-config --config <path>` を実行すると、設定ファイルを読み込んで妥当性を検証した上で終了コード 0/1 を返します。CI での事前検証に便利です。
 
+`--config` で読み込んだ設定は CLI 実行時にも自動検証され、不正な値が含まれている場合はエラーとして停止します。`--validate-config` では検証結果と併せて、検査したテンプレート数や post エントリ数を出力します。
+
 ## 設定ファイルの利用
 繰り返し利用する設定は JSON ファイルにまとめておくのがおすすめです。`--config <path>` を指定すると、ファイル内の値を既定値として読み込み、CLI 引数で上書きできます。
 

--- a/scripts/lib/share-config-validator.js
+++ b/scripts/lib/share-config-validator.js
@@ -1,0 +1,179 @@
+const ALLOWED_FORMATS = new Set(['text', 'markdown', 'json']);
+
+function isObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateString(value, path, errors, { allowEmpty = false } = {}) {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (typeof value !== 'string') {
+    errors.push(`${path} must be a string`);
+    return;
+  }
+  if (!allowEmpty && value.trim().length === 0) {
+    errors.push(`${path} must not be empty`);
+  }
+}
+
+function validateBoolean(value, path, errors) {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (typeof value !== 'boolean') {
+    errors.push(`${path} must be a boolean`);
+  }
+}
+
+function validateNumber(value, path, errors, { min, allowFloat = true }) {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (typeof value !== 'number') {
+    errors.push(`${path} must be a number`);
+    return;
+  }
+  if (!allowFloat && !Number.isInteger(value)) {
+    errors.push(`${path} must be an integer`);
+    return;
+  }
+  if (min !== undefined && value < min) {
+    errors.push(`${path} must be >= ${min}`);
+  }
+}
+
+function validatePostEntry(entry, path, errors, summary) {
+  if (typeof entry === 'string') {
+    if (entry.trim().length === 0) {
+      errors.push(`${path} must not be empty`);
+    } else {
+      summary.posts += 1;
+    }
+    return;
+  }
+
+  if (!isObject(entry)) {
+    errors.push(`${path} must be a string or object`);
+    return;
+  }
+
+  validateString(entry.url ?? entry.href ?? entry.target, `${path}.url`, errors);
+  if (!errors.some((message) => message.startsWith(`${path}.url`))) {
+    summary.posts += 1;
+  }
+
+  validateNumber(entry.retry, `${path}.retry`, errors, { min: 0, allowFloat: false });
+  validateNumber(entry.retryDelay ?? entry.retryDelayMs, `${path}.retryDelay`, errors, {
+    min: 0,
+    allowFloat: false,
+  });
+  validateNumber(entry.retryBackoff, `${path}.retryBackoff`, errors, { min: 1 });
+  validateNumber(entry.retryMaxDelay ?? entry.retryMaxDelayMs, `${path}.retryMaxDelay`, errors, {
+    min: 0,
+    allowFloat: false,
+  });
+  validateNumber(entry.retryJitter ?? entry.retryJitterMs, `${path}.retryJitter`, errors, {
+    min: 0,
+    allowFloat: false,
+  });
+
+  validateBoolean(entry['ensure-ok'] ?? entry.ensureOk, `${path}.ensure-ok`, errors);
+  validateBoolean(entry['respect-retry-after'] ?? entry.respectRetryAfter, `${path}.respect-retry-after`, errors);
+}
+
+function validateProjectsApi(projectsApi, path, errors) {
+  if (!isObject(projectsApi)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+  validateString(projectsApi.baseUrl, `${path}.baseUrl`, errors);
+  validateString(projectsApi.token, `${path}.token`, errors);
+  validateString(projectsApi.tenant, `${path}.tenant`, errors);
+  validateNumber(projectsApi.timeoutMs ?? projectsApi.timeout, `${path}.timeout`, errors, {
+    min: 1,
+    allowFloat: false,
+  });
+  validateBoolean(projectsApi.fetchMetrics, `${path}.fetchMetrics`, errors);
+}
+
+function validateShareConfigObject(config, path, errors, summary) {
+  if (!isObject(config)) {
+    errors.push(`${path} must be an object`);
+    return;
+  }
+
+  validateString(config.url, `${path}.url`, errors);
+  if (typeof config.url === 'string' && config.url.trim()) {
+    summary.urls += 1;
+  }
+  validateString(config.title, `${path}.title`, errors);
+  validateString(config.notes, `${path}.notes`, errors);
+  validateString(config.out, `${path}.out`, errors);
+  validateString(config['audit-log'] ?? config.auditLog, `${path}.audit-log`, errors);
+  validateString(config.format, `${path}.format`, errors);
+  if (typeof config.format === 'string' && !ALLOWED_FORMATS.has(config.format.toLowerCase())) {
+    errors.push(`${path}.format must be one of text | markdown | json`);
+  }
+
+  validateNumber(config.count, `${path}.count`, errors, { min: 0, allowFloat: false });
+  validateNumber(config.retry, `${path}.retry`, errors, { min: 0, allowFloat: false });
+  validateNumber(config.retryDelay ?? config['retry-delay'], `${path}.retryDelay`, errors, {
+    min: 0,
+    allowFloat: false,
+  });
+  validateNumber(config.retryBackoff ?? config['retry-backoff'], `${path}.retryBackoff`, errors, { min: 1 });
+  validateNumber(config.retryMaxDelay ?? config['retry-max-delay'], `${path}.retryMaxDelay`, errors, {
+    min: 0,
+    allowFloat: false,
+  });
+  validateNumber(config.retryJitter ?? config['retry-jitter'], `${path}.retryJitter`, errors, {
+    min: 0,
+    allowFloat: false,
+  });
+  validateBoolean(config['ensure-ok'] ?? config.ensureOk, `${path}.ensure-ok`, errors);
+  validateBoolean(config['respect-retry-after'] ?? config.respectRetryAfter, `${path}.respect-retry-after`, errors);
+  validateBoolean(config['fetch-metrics'] ?? config.fetchMetrics, `${path}.fetch-metrics`, errors);
+
+  validateString(config.template ?? config.defaultTemplate ?? config['default-template'], `${path}.template`, errors);
+
+  const post = config.post;
+  if (post !== undefined) {
+    const entries = Array.isArray(post) ? post : [post];
+    entries.forEach((entry, index) => {
+      validatePostEntry(entry, `${path}.post[${index}]`, errors, summary);
+    });
+  }
+
+  if (config.projectsApi) {
+    validateProjectsApi(config.projectsApi, `${path}.projectsApi`, errors);
+  }
+
+  if (config.templates !== undefined) {
+    if (!isObject(config.templates)) {
+      errors.push(`${path}.templates must be an object whose keys are template names`);
+    } else {
+      Object.entries(config.templates).forEach(([name, templateConfig]) => {
+        validateShareConfigObject(templateConfig, `${path}.templates.${name}`, errors, summary);
+        summary.templates += 1;
+      });
+    }
+  }
+}
+
+function validateShareConfig(config) {
+  const errors = [];
+  const summary = {
+    templates: 0,
+    posts: 0,
+    urls: 0,
+  };
+
+  validateShareConfigObject(config, 'config', errors, summary);
+
+  return { errors, summary };
+}
+
+module.exports = {
+  validateShareConfig,
+};

--- a/ui-poc/tests/share-cli/project-share-slack.test.ts
+++ b/ui-poc/tests/share-cli/project-share-slack.test.ts
@@ -1046,7 +1046,7 @@ describe("project-share-slack CLI", () => {
       );
       const result = runScriptRaw(["--config", configPath, "--validate-config"]);
       expect(result.status).toBe(0);
-      expect(result.stdout).toContain("Config validation succeeded.");
+      expect(result.stdout).toContain("Config validation succeeded (templates: 0, post entries: 1).");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- introduce `scripts/lib/share-config-validator` to rigorously check global config, templates, and per-webhook overrides
- fail fast when invalid values are detected and surface counts in `--validate-config` output
- enrich dry-run audit logging so entries mirror real attempts while leaving webhooks untouched

## Testing
- npm run test:share-cli
