### PR TITLE
feat: add electronic ledger terraform stack

### DIFF
--- a/.github/workflows/terraform-compliance.yml
+++ b/.github/workflows/terraform-compliance.yml
@@ -1,0 +1,37 @@
+name: Terraform Compliance Stack
+
+on:
+  pull_request:
+    paths:
+      - 'iac/**'
+  workflow_dispatch:
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: iac/stacks/electronic-ledger
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.0
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+      - name: Terraform init
+        run: terraform init
+      - name: Terraform validate
+        run: terraform validate
+      - name: Terraform plan
+        env:
+          TF_VAR_aws_region: ap-northeast-1
+          TF_VAR_ledger_bucket_name: demo-ledger-bucket
+          TF_VAR_aws_account_id: "000000000000"
+          TF_VAR_account_admin_arn: arn:aws:iam::000000000000:role/Dummy
+          TF_VAR_skip_credentials_validation: "true"
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+          AWS_DEFAULT_REGION: ap-northeast-1
+          TF_VAR_environment: ci
+        run: terraform plan -input=false -lock=false

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 ## Finance & Compliance
 - [契約/請求 ERD](contracts/erd.md)
 - [電子帳簿法チェックリスト](compliance/electronic-book.md)
+- [電子帳簿法対応 Runbook](compliance/electronic-ledger-runbook.md)
 
 ## Services
 - [Project API (NestJS)](../services/project-api/README.md)

--- a/docs/compliance/electronic-ledger-runbook.md
+++ b/docs/compliance/electronic-ledger-runbook.md
@@ -1,0 +1,28 @@
+# 電子帳簿法対応 Runbook
+
+## 目的
+S3 Object Lock + KMS + DynamoDB を利用した電子帳簿法（WORM）準拠のストレージを Terraform で管理します。
+
+## 手順概要
+1. `iac/stacks/electronic-ledger/backend.tf.example` と `backend.hcl.example` をコピーし、S3 バケット / DynamoDB テーブルを設定
+2. `terraform init -backend-config=backend.hcl` を実行して初期化
+3. `terraform plan` で差分を確認
+4. `terraform apply` で本番 / QA 環境へデプロイ
+
+## バケット構成
+- バージョニング + Object Lock (COMPLIANCE モード)
+- 非現行バージョンは 365 日後に削除
+- 90 日後に Glacier Instant Retrieval へ自動移行
+- CMK で暗号化し、アクセス許可は最小限に制限
+
+## 監視
+- CloudWatch アラーム `4xxErrors` (PUT 失敗) を SNS トピックへ通知
+- DynamoDB でログのインデックスを保持し、PITR を有効化
+
+## CI
+- `.github/workflows/terraform-compliance.yml` で `terraform fmt`, `validate`, `plan` を自動チェック
+- `TF_VAR_environment=ci` + `TF_VAR_skip_credentials_validation=true` でダミー認証のまま差分検知
+
+## 想定トラブルシュート
+- **アラームが発火した場合**: CloudTrail で失敗した API を確認し、権限設定を見直す
+- **WORM モードの解除要求**: Object Lock は変更不可のため、監査部門承認のうえ新バケットへ移行する

--- a/iac/modules/electronic-ledger/main.tf
+++ b/iac/modules/electronic-ledger/main.tf
@@ -1,0 +1,171 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(
+    var.tags,
+    {
+      Compliance = "ElectronicLedger"
+      ManagedBy  = "terraform"
+    }
+  )
+}
+
+resource "aws_kms_key" "ledger" {
+  description             = var.kms_description
+  deletion_window_in_days = var.kms_deletion_window
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { AWS = var.account_admin_arn }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Effect    = "Allow"
+        Principal = { Service = "s3.amazonaws.com" }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:CallerAccount" = var.aws_account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket" "ledger" {
+  bucket              = var.bucket_name
+  force_destroy       = var.force_destroy
+  object_lock_enabled = true
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "ledger" {
+  bucket                  = aws_s3_bucket.ledger.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "ledger" {
+  bucket = aws_s3_bucket.ledger.id
+
+  versioning_configuration {
+    status     = "Enabled"
+    mfa_delete = var.versioning_mfa_delete
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ledger" {
+  bucket = aws_s3_bucket.ledger.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.ledger.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "ledger" {
+  bucket = aws_s3_bucket.ledger.id
+
+  rule {
+    default_retention {
+      mode = var.object_lock_mode
+      days = var.object_lock_retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "ledger" {
+  bucket = aws_s3_bucket.ledger.id
+
+  rule {
+    id     = "glacier-archive"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    transition {
+      days          = var.glacier_transition_days
+      storage_class = "GLACIER_IR"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.expire_noncurrent_after_days
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "ledger_log" {
+  name         = var.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LedgerId"
+  range_key    = "Timestamp"
+
+  attribute {
+    name = "LedgerId"
+    type = "S"
+  }
+
+  attribute {
+    name = "Timestamp"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "s3_put_failures" {
+  count               = var.enable_put_alarm ? 1 : 0
+  alarm_name          = "${var.bucket_name}-put-failures"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "4xxErrors"
+  namespace           = "AWS/S3"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "Notifies when the ledger bucket experiences failed PUT operations"
+
+  dimensions = {
+    BucketName  = aws_s3_bucket.ledger.bucket
+    StorageType = "AllStorageTypes"
+  }
+
+  alarm_actions = var.alarm_topics
+  ok_actions    = var.alarm_topics
+
+  tags = local.common_tags
+}

--- a/iac/modules/electronic-ledger/outputs.tf
+++ b/iac/modules/electronic-ledger/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_id" {
+  value       = aws_s3_bucket.ledger.id
+  description = "ID of the ledger bucket"
+}
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.ledger.arn
+  description = "ARN of the ledger bucket"
+}
+
+output "kms_key_arn" {
+  value       = aws_kms_key.ledger.arn
+  description = "ARN of the KMS CMK"
+}
+
+output "dynamodb_table_name" {
+  value       = aws_dynamodb_table.ledger_log.name
+  description = "Name of the DynamoDB ledger table"
+}

--- a/iac/modules/electronic-ledger/variables.tf
+++ b/iac/modules/electronic-ledger/variables.tf
@@ -1,0 +1,86 @@
+variable "bucket_name" {
+  description = "Name of the compliance archive bucket"
+  type        = string
+}
+
+variable "force_destroy" {
+  description = "Allow terraform to delete bucket even if it contains objects"
+  type        = bool
+  default     = false
+}
+
+variable "versioning_mfa_delete" {
+  description = "Enable MFA delete for versioned bucket"
+  type        = string
+  default     = "Disabled"
+}
+
+variable "object_lock_mode" {
+  description = "WORM retention mode"
+  type        = string
+  default     = "COMPLIANCE"
+}
+
+variable "object_lock_retention_days" {
+  description = "Default object lock retention period"
+  type        = number
+  default     = 365
+}
+
+variable "glacier_transition_days" {
+  description = "Days before transitioning objects to Glacier"
+  type        = number
+  default     = 90
+}
+
+variable "expire_noncurrent_after_days" {
+  description = "Days before removing non-current versions"
+  type        = number
+  default     = 365
+}
+
+variable "kms_description" {
+  description = "Description for the KMS key"
+  type        = string
+  default     = "Electronic ledger CMK"
+}
+
+variable "kms_deletion_window" {
+  description = "KMS deletion window in days"
+  type        = number
+  default     = 30
+}
+
+variable "aws_account_id" {
+  description = "AWS account id for access control"
+  type        = string
+}
+
+variable "account_admin_arn" {
+  description = "IAM principal allowed full access to the CMK"
+  type        = string
+}
+
+variable "dynamodb_table_name" {
+  description = "Ledger index DynamoDB table name"
+  type        = string
+  default     = "electronic-ledger-log"
+}
+
+variable "enable_put_alarm" {
+  description = "Enable CloudWatch alarm for failed PUT operations"
+  type        = bool
+  default     = true
+}
+
+variable "alarm_topics" {
+  description = "SNS topics to notify on alarm"
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Resource tags"
+  type        = map(string)
+  default     = {}
+}

--- a/iac/stacks/electronic-ledger/README.md
+++ b/iac/stacks/electronic-ledger/README.md
@@ -1,0 +1,15 @@
+# Electronic Ledger Stack
+
+Usage:
+
+```bash
+cd iac/stacks/electronic-ledger
+cp backend.tf.example backend.tf
+cp backend.hcl.example backend.hcl
+terraform init -backend-config=backend.hcl
+terraform plan -var="aws_region=ap-northeast-1" \
+  -var="ledger_bucket_name=ledger-worm-example" \
+  -var="aws_account_id=123456789012" \
+  -var="account_admin_arn=arn:aws:iam::123456789012:role/Admin" \
+  -var="environment=qa"
+```

--- a/iac/stacks/electronic-ledger/backend.hcl.example
+++ b/iac/stacks/electronic-ledger/backend.hcl.example
@@ -1,0 +1,5 @@
+bucket         = "my-terraform-state"
+key            = "electronic-ledger/terraform.tfstate"
+region         = "ap-northeast-1"
+dynamodb_table = "terraform-lock"
+encrypt        = true

--- a/iac/stacks/electronic-ledger/backend.tf.example
+++ b/iac/stacks/electronic-ledger/backend.tf.example
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {}
+}

--- a/iac/stacks/electronic-ledger/main.tf
+++ b/iac/stacks/electronic-ledger/main.tf
@@ -1,0 +1,26 @@
+locals {
+  base_tags = {
+    Environment = var.environment
+    Service     = "ElectronicLedger"
+  }
+
+  merged_tags = merge(local.base_tags, var.tags)
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  skip_credentials_validation = var.skip_credentials_validation
+  skip_metadata_api_check     = var.skip_credentials_validation
+  skip_region_validation      = var.skip_credentials_validation
+  skip_requesting_account_id  = var.skip_credentials_validation
+}
+
+module "ledger" {
+  source = "../../modules/electronic-ledger"
+
+  bucket_name       = var.ledger_bucket_name
+  aws_account_id    = var.aws_account_id
+  account_admin_arn = var.account_admin_arn
+  alarm_topics      = var.alarm_topics
+  tags              = local.merged_tags
+}

--- a/iac/stacks/electronic-ledger/outputs.tf
+++ b/iac/stacks/electronic-ledger/outputs.tf
@@ -1,0 +1,11 @@
+output "bucket_arn" {
+  value = module.ledger.bucket_arn
+}
+
+output "kms_key_arn" {
+  value = module.ledger.kms_key_arn
+}
+
+output "dynamodb_table" {
+  value = module.ledger.dynamodb_table_name
+}

--- a/iac/stacks/electronic-ledger/variables.tf
+++ b/iac/stacks/electronic-ledger/variables.tf
@@ -1,0 +1,43 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "ledger_bucket_name" {
+  description = "Ledger S3 bucket name"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "AWS account id"
+  type        = string
+}
+
+variable "account_admin_arn" {
+  description = "Principal with admin access to ledger resources"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment for tagging (e.g., prod, qa, sandbox)"
+  type        = string
+  default     = "sandbox"
+}
+
+variable "tags" {
+  description = "Common resource tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "skip_credentials_validation" {
+  description = "Skip AWS credential and region validation (set true for CI/dry-run)"
+  type        = bool
+  default     = false
+}
+
+variable "alarm_topics" {
+  description = "SNS topics for alarm notifications"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add reusable electronic-ledger Terraform module (S3 Object Lock + KMS + DynamoDB)
- add electronic-ledger stack with CI-friendly provider config and tagging
- document runbook and wire github actions plan workflow

## Issue
- closes #270

## Testing
- terraform fmt -recursive iac
- terraform init
- terraform validate
- terraform plan -var skip_credentials_validation=true