### PR TITLE
feat: add project AI dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,4 @@ GitHub Actions には週次スケジュール (`Projects Slack Share Check`) を
 ## Services
 - [Project API (NestJS)](services/project-api/README.md)
 - [API ドキュメント (OpenAPI/GraphQL)](docs/api/README.md)
+- [Project Dashboard (AI ハイライト)](docs/projects/project-dashboard.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,3 +37,4 @@
 ## Services
 - [Project API (NestJS)](../services/project-api/README.md)
 - [Contract Invoice Pipeline](contracts/invoice-pipeline.md)
+- [Project Dashboard (AI ハイライト)](projects/project-dashboard.md)

--- a/docs/projects/project-dashboard.md
+++ b/docs/projects/project-dashboard.md
@@ -1,0 +1,31 @@
+# プロジェクトダッシュボード（AI ハイライト）
+
+## 概要
+`/projects` 画面に AI ハイライトと EVM/リスク指標を統合したダッシュボードを追加しました。ChatSummarizer が算出した要約・EVM 指標・バーンダウン・リスクを 1 画面で確認でき、アクション判断を素早く行えます。
+
+## 表示内容
+- **日次ハイライト**: ChatSummarizer の要約と EVM 指標から自動生成される bullet。CPI/SPI・スケジュール遅延・高リスク情報を優先度付きで提示します。
+- **EVM スナップショット**: Planned/Earned/Actual Cost、CPI・SPI による効率判断、Cost/Schedule Variance を表示。
+- **バーンダウン進捗**: 計画値と実績値を比較し、「前倒し／遅れ／オン・トラック」を判定。
+- **今後の主要タスク**: タイムラインの先頭 5 件をステータス別に表示。
+- **リスクサマリ**: 発生確率 × 影響度を基に上位 5 件を表示。
+
+## データソースとフォールバック
+1. GraphQL `projectTimeline` / `projectMetrics`
+2. REST `/api/v1/projects/:id/timeline` / `/api/v1/projects/:id/metrics`
+3. モックデータ（PoC 用）
+
+パネル右上に「API / REST / MOCK」のステータスを表示し、取得元を明示します。更新ボタンで再取得が可能です。
+
+## 推奨運用
+- 毎朝スタンドアップ／週次レビュー時に「日次ハイライト」を読み上げ、重大リスクがあれば即エスカレーション。
+- CPI/SPI・Variance をもとに、稼働計画／コスト見直しを判断。
+- リスク情報を `contracts/invoice-pipeline.md` の対応手順と合わせてトリアージ。
+
+## テスト
+- Playwright `tests/e2e/projects.spec.ts` でハイライト表示を検証（GraphQL 失敗時のモックフォールバックもカバー）。
+- `./scripts/generate-api-docs.sh` 実行で GraphQL スキーマに変更がないか確認。
+
+## 今後の拡張例
+- チャット検索結果（Issue #280）を同パネルに統合し、キーワードフィードバックを可視化。
+- KPI のトレンド表示（7日移動平均）や Slack 通知との連携を検討。

--- a/ui-poc/package-lock.json
+++ b/ui-poc/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.56.0",
+        "clsx": "^2.1.0",
+        "lucide-react": "^0.452.0",
         "next": "14.2.5",
         "react": "^18",
         "react-dom": "^18"
@@ -2840,6 +2842,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5454,6 +5465,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.452.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.452.0.tgz",
+      "integrity": "sha512-kNefjOUOGm+Mu3KDiryONyPba9r+nhcrz5oJs3N6JDzGboQNEXw5GB3yB8rnV9/FA4bPyggNU6CRSihZm9MvSw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/ui-poc/package.json
+++ b/ui-poc/package.json
@@ -15,6 +15,8 @@
     "test:e2e:live": "E2E_EXPECT_API=true playwright test"
   },
   "dependencies": {
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.452.0",
     "@tanstack/react-query": "^5.56.0",
     "next": "14.2.5",
     "react": "^18",

--- a/ui-poc/src/features/projects/ProjectInsightsPanel.tsx
+++ b/ui-poc/src/features/projects/ProjectInsightsPanel.tsx
@@ -1,0 +1,208 @@
+import { memo, useMemo } from "react";
+import { RefreshCcw } from "lucide-react";
+import clsx from "clsx";
+import { useProjectInsights } from "./useProjectInsights";
+import type { ProjectSummary } from "./types";
+
+type Props = {
+  projects: ProjectSummary[];
+  selectedProjectId: string | null;
+  onSelectProject: (projectId: string | null) => void;
+  listLoading?: boolean;
+};
+
+const severityClass: Record<"good" | "warning" | "critical", string> = {
+  good: "bg-emerald-500/10 text-emerald-300 border border-emerald-500/40",
+  warning: "bg-amber-500/10 text-amber-300 border border-amber-500/40",
+  critical: "bg-rose-500/10 text-rose-300 border border-rose-500/40",
+};
+
+const statusBadge: Record<string, string> = {
+  todo: "bg-slate-700 text-slate-200",
+  inProgress: "bg-sky-700 text-sky-100",
+  review: "bg-purple-700 text-purple-100",
+  done: "bg-emerald-700 text-emerald-100",
+  blocked: "bg-rose-700 text-rose-100",
+};
+
+export const ProjectInsightsPanel = memo(function ProjectInsightsPanel({ projects, selectedProjectId, onSelectProject, listLoading }: Props) {
+  const hasProjects = projects.length > 0;
+  const defaultProject = hasProjects ? projects[0] : null;
+  const effectiveProjectId = selectedProjectId ?? defaultProject?.id ?? null;
+  const selectedProject = useMemo(() => projects.find((project) => project.id === effectiveProjectId) ?? null, [projects, effectiveProjectId]);
+  const { insights, highlight, loading, error, source, refresh, burndownTrend } = useProjectInsights(effectiveProjectId);
+
+  const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    onSelectProject(value.length > 0 ? value : null);
+  };
+
+  return (
+    <section className="space-y-4 rounded-lg border border-slate-700 bg-slate-900/80 p-4 shadow-sm" data-testid="project-insights-panel">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold text-white">AI ハイライト & ダッシュボード</h3>
+          <p className="text-xs text-slate-400">タイムライン、EVM、リスクを自動集約し、重要な着眼点を提示します。</p>
+        </div>
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+          <select
+            value={effectiveProjectId ?? ""}
+            onChange={handleSelect}
+            className="rounded-md border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-slate-100 shadow-sm outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500"
+            disabled={!hasProjects || listLoading}
+            data-testid="project-insights-selector"
+          >
+            {projects.length === 0 ? <option value="">プロジェクトがありません</option> : null}
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.code} — {project.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center gap-2 rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-xs font-medium text-slate-200 transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+            onClick={refresh}
+            disabled={loading || !effectiveProjectId}
+            data-testid="project-insights-refresh"
+          >
+            <RefreshCcw className={clsx("h-4 w-4", loading && "animate-spin")} aria-hidden="true" />
+            更新
+          </button>
+        </div>
+      </header>
+
+      {!hasProjects ? (
+        <p className="rounded-md border border-dashed border-slate-700 bg-slate-800/60 p-4 text-sm text-slate-300">
+          表示可能なプロジェクトがありません。フィルタ条件を変更するか、新しいプロジェクトを作成してください。
+        </p>
+      ) : null}
+
+      {effectiveProjectId && selectedProject ? (
+        <div className="grid gap-4 lg:grid-cols-3">
+          <div className="space-y-3 lg:col-span-2">
+            <div
+              className={clsx(
+                "space-y-3 rounded-lg border p-4",
+                highlight ? severityClass[highlight.severity] : "border-slate-700 bg-slate-800 text-slate-200",
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">日次ハイライト</p>
+                  <h4 className="text-base font-semibold">{highlight?.headline ?? "進捗情報を取得しています…"}</h4>
+                </div>
+                <span className="rounded-full bg-slate-900/40 px-2 py-1 text-[10px] uppercase tracking-wide text-slate-300">
+                  {loading ? "取得中" : source === "graphql" ? "API" : source === "rest" ? "REST" : source === "mock" ? "MOCK" : "待機中"}
+                </span>
+              </div>
+              <ul className="space-y-2 text-sm leading-relaxed text-slate-100">
+                {highlight?.bullets.map((bullet) => (
+                  <li key={bullet} className="flex items-start gap-2">
+                    <span className="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-sky-400" aria-hidden="true" />
+                    <span>{bullet}</span>
+                  </li>
+                ))}
+                {loading ? <li className="animate-pulse text-slate-400">AI ハイライトを解析しています…</li> : null}
+              </ul>
+              {error ? <p className="text-xs text-rose-300">データ取得に失敗しました: {error}</p> : null}
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-4 text-sm text-slate-200">
+                <p className="text-xs uppercase tracking-wide text-slate-400">EVM スナップショット</p>
+                <dl className="mt-3 grid grid-cols-2 gap-2">
+                  <div>
+                    <dt className="text-[11px] text-slate-400">Planned Value</dt>
+                    <dd className="font-mono text-sm">{insights?.metrics.evm.plannedValue.toLocaleString()} 円</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[11px] text-slate-400">Earned Value</dt>
+                    <dd className="font-mono text-sm">{insights?.metrics.evm.earnedValue.toLocaleString()} 円</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[11px] text-slate-400">Actual Cost</dt>
+                    <dd className="font-mono text-sm">{insights?.metrics.evm.actualCost.toLocaleString()} 円</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[11px] text-slate-400">CPI / SPI</dt>
+                    <dd className="font-mono text-sm">
+                      {insights ? insights.metrics.evm.cpi.toFixed(2) : "--"} / {insights ? insights.metrics.evm.spi.toFixed(2) : "--"}
+                    </dd>
+                  </div>
+                  <div className="col-span-2">
+                    <dt className="text-[11px] text-slate-400">Variance</dt>
+                    <dd className="font-mono text-sm">
+                      CV {insights ? insights.metrics.evm.costVariance.toLocaleString() : "--"} 円 / SV{" "}
+                      {insights ? insights.metrics.evm.scheduleVariance.toLocaleString() : "--"} 円
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-4 text-sm text-slate-200">
+                <p className="text-xs uppercase tracking-wide text-slate-400">バーンダウン進捗</p>
+                <p className="mt-1 text-xs text-slate-400">
+                  {burndownTrend === "ahead" ? "予定より完了量が進んでいます。" : burndownTrend === "behind" ? "計画線より遅れ気味です。" : "計画ラインに沿って進行中。"}
+                </p>
+                <table className="mt-3 w-full table-fixed border-collapse text-xs">
+                  <thead>
+                    <tr className="text-slate-400">
+                      <th className="w-1/3 border-b border-slate-700 pb-1 text-left font-medium">期間</th>
+                      <th className="w-1/3 border-b border-slate-700 pb-1 text-right font-medium">計画</th>
+                      <th className="w-1/3 border-b border-slate-700 pb-1 text-right font-medium">実績</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {insights?.metrics.burndown.labels.map((label, index) => (
+                      <tr key={label} className="border-b border-slate-800 text-slate-200">
+                        <td className="py-1">{label}</td>
+                        <td className="py-1 text-right">{insights.metrics.burndown.planned[index]?.toFixed(0)}</td>
+                        <td className="py-1 text-right">{insights.metrics.burndown.actual[index]?.toFixed(0)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          <aside className="space-y-3 rounded-lg border border-slate-700 bg-slate-800/60 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-400">今後の主なタスク</p>
+            <ul className="space-y-2 text-sm text-slate-100">
+              {insights?.timeline.tasks.slice(0, 5).map((task) => (
+                <li key={task.id} className="flex flex-col rounded border border-slate-700 bg-slate-900/70 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-slate-50">{task.name}</span>
+                    <span className={clsx("rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wide", statusBadge[task.status] ?? "bg-slate-700 text-slate-200")}>
+                      {task.status}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-slate-400">
+                    {task.startDate} → {task.endDate} {task.phase ? `（${task.phase}）` : ""}
+                  </p>
+                </li>
+              ))}
+              {insights && insights.timeline.tasks.length === 0 ? <li className="text-xs text-slate-400">タイムラインに未登録のタスクがあります。</li> : null}
+            </ul>
+
+            <div className="rounded border border-slate-700 bg-slate-900/70 p-3 text-sm text-slate-200">
+              <p className="text-xs uppercase tracking-wide text-slate-400">リスクサマリ</p>
+              <ul className="mt-2 space-y-2">
+                {insights?.metrics.risks.slice(0, 5).map((risk) => (
+                  <li key={risk.id} className="rounded border border-slate-700/70 bg-slate-800/70 p-2">
+                    <p className="text-xs text-slate-400">
+                      影響 {risk.impact} / 確率 {risk.probability}
+                    </p>
+                    <p className="font-medium text-slate-100">{risk.status}</p>
+                  </li>
+                ))}
+                {insights && insights.metrics.risks.length === 0 ? <li className="text-xs text-slate-400">登録されたリスクはありません。</li> : null}
+              </ul>
+            </div>
+          </aside>
+        </div>
+      ) : null}
+    </section>
+  );
+});

--- a/ui-poc/src/features/projects/insights-mock.ts
+++ b/ui-poc/src/features/projects/insights-mock.ts
@@ -1,0 +1,131 @@
+import type { ProjectInsights } from "./types";
+
+export const mockProjectInsights: Record<string, ProjectInsights> = {
+  "PRJ-1001": {
+    timeline: {
+      projectId: "PRJ-1001",
+      chatSummary: "主要タスクは計画通り進捗。今週はデータ連携の統合作業を完了し、来週から UAT に入ります。",
+      chatSummaryLanguage: "ja",
+      metrics: {
+        plannedValue: 1_200_000,
+        earnedValue: 1_080_000,
+        actualCost: 950_000,
+        costVariance: 130_000,
+        scheduleVariance: -120_000,
+        cpi: 1.14,
+        spi: 0.90,
+      },
+      phases: [
+        { id: "phase-plan", name: "計画", sortOrder: 1 },
+        { id: "phase-build", name: "構築", sortOrder: 2 },
+        { id: "phase-uat", name: "UAT", sortOrder: 3 },
+        { id: "phase-deploy", name: "リリース", sortOrder: 4 },
+      ],
+      tasks: [
+        {
+          id: "task-101",
+          name: "要件レビュー",
+          phase: "計画",
+          startDate: "2025-04-01",
+          endDate: "2025-04-19",
+          status: "done",
+        },
+        {
+          id: "task-102",
+          name: "基盤設計",
+          phase: "構築",
+          startDate: "2025-04-20",
+          endDate: "2025-05-12",
+          status: "inProgress",
+        },
+        {
+          id: "task-103",
+          name: "データ連携テスト",
+          phase: "構築",
+          startDate: "2025-05-13",
+          endDate: "2025-05-25",
+          status: "inProgress",
+        },
+        {
+          id: "task-104",
+          name: "性能テスト準備",
+          phase: "UAT",
+          startDate: "2025-05-26",
+          endDate: "2025-06-03",
+          status: "todo",
+        },
+      ],
+    },
+    metrics: {
+      projectId: "PRJ-1001",
+      evm: {
+        plannedValue: 1_200_000,
+        earnedValue: 1_080_000,
+        actualCost: 950_000,
+        costVariance: 130_000,
+        scheduleVariance: -120_000,
+        cpi: 1.14,
+        spi: 0.90,
+      },
+      burndown: {
+        labels: ["Week 1", "Week 2", "Week 3", "Week 4", "Week 5"],
+        planned: [100, 80, 60, 40, 20],
+        actual: [100, 85, 70, 55, 35],
+      },
+      risks: [
+        { id: "risk-1", probability: 4, impact: 4, status: "監視中" },
+        { id: "risk-2", probability: 2, impact: 5, status: "緩和中" },
+      ],
+    },
+  },
+};
+
+const defaultInsight: ProjectInsights = mockProjectInsights["PRJ-1001"] ?? {
+  timeline: {
+    projectId: "mock-project",
+    chatSummary: "最新の更新はありませんが、計画通り進行しています。",
+    chatSummaryLanguage: "ja",
+    metrics: {
+      plannedValue: 1_000_000,
+      earnedValue: 950_000,
+      actualCost: 900_000,
+      costVariance: 50_000,
+      scheduleVariance: -80_000,
+      cpi: 1.06,
+      spi: 0.92,
+    },
+    phases: [],
+    tasks: [],
+  },
+  metrics: {
+    projectId: "mock-project",
+    evm: {
+      plannedValue: 1_000_000,
+      earnedValue: 950_000,
+      actualCost: 900_000,
+      costVariance: 50_000,
+      scheduleVariance: -80_000,
+      cpi: 1.06,
+      spi: 0.92,
+    },
+    burndown: {
+      labels: ["Week 1", "Week 2", "Week 3", "Week 4"],
+      planned: [100, 75, 50, 25],
+      actual: [100, 80, 55, 30],
+    },
+    risks: [],
+  },
+};
+
+export function getMockProjectInsights(projectId: string): ProjectInsights {
+  return mockProjectInsights[projectId] ?? {
+    timeline: {
+      ...defaultInsight.timeline,
+      projectId,
+    },
+    metrics: {
+      ...defaultInsight.metrics,
+      projectId,
+    },
+  };
+}

--- a/ui-poc/src/features/projects/queries.ts
+++ b/ui-poc/src/features/projects/queries.ts
@@ -88,3 +88,58 @@ export const PROJECT_TRANSITION_MUTATION = `#graphql
     }
   }
 `;
+
+export const PROJECT_INSIGHTS_QUERY = `#graphql
+  query ProjectInsights($projectId: String!) {
+    timeline: projectTimeline(projectId: $projectId) {
+      projectId
+      chatSummary
+      chatSummaryLanguage
+      metrics {
+        plannedValue
+        earnedValue
+        actualCost
+        costVariance
+        scheduleVariance
+        cpi
+        spi
+      }
+      tasks {
+        id
+        name
+        phase
+        startDate
+        endDate
+        status
+      }
+      phases {
+        id
+        name
+        sortOrder
+      }
+    }
+    metrics: projectMetrics(projectId: $projectId) {
+      projectId
+      evm {
+        plannedValue
+        earnedValue
+        actualCost
+        costVariance
+        scheduleVariance
+        cpi
+        spi
+      }
+      burndown {
+        labels
+        planned
+        actual
+      }
+      risks {
+        id
+        probability
+        impact
+        status
+      }
+    }
+  }
+`;

--- a/ui-poc/src/features/projects/types.ts
+++ b/ui-poc/src/features/projects/types.ts
@@ -36,3 +36,62 @@ export const STATUS_LABEL: Record<ProjectStatus, string> = {
   onhold: "On Hold",
   closed: "Closed",
 };
+
+export type TimelineTask = {
+  id: string;
+  name: string;
+  phase?: string;
+  startDate: string;
+  endDate: string;
+  status: "todo" | "inProgress" | "review" | "done" | "blocked";
+};
+
+export type TimelinePhase = {
+  id: string;
+  name: string;
+  sortOrder: number;
+};
+
+export type EvmSnapshot = {
+  plannedValue: number;
+  earnedValue: number;
+  actualCost: number;
+  costVariance: number;
+  scheduleVariance: number;
+  cpi: number;
+  spi: number;
+};
+
+export type BurndownSeries = {
+  labels: string[];
+  planned: number[];
+  actual: number[];
+};
+
+export type RiskSummary = {
+  id: string;
+  probability: number;
+  impact: number;
+  status: string;
+};
+
+export type ProjectTimeline = {
+  projectId: string;
+  metrics: EvmSnapshot;
+  tasks: TimelineTask[];
+  phases: TimelinePhase[];
+  chatSummary?: string;
+  chatSummaryLanguage?: string;
+};
+
+export type ProjectMetrics = {
+  projectId: string;
+  evm: EvmSnapshot;
+  burndown: BurndownSeries;
+  risks: RiskSummary[];
+};
+
+export type ProjectInsights = {
+  timeline: ProjectTimeline;
+  metrics: ProjectMetrics;
+};

--- a/ui-poc/src/features/projects/useProjectInsights.ts
+++ b/ui-poc/src/features/projects/useProjectInsights.ts
@@ -1,0 +1,205 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { apiRequest, graphqlRequest } from "@/lib/api-client";
+import { PROJECT_INSIGHTS_QUERY } from "./queries";
+import { getMockProjectInsights } from "./insights-mock";
+import type { BurndownSeries, ProjectInsights, ProjectMetrics, ProjectTimeline } from "./types";
+
+type InsightSource = "graphql" | "rest" | "mock" | "idle";
+
+type HighlightSummary = {
+  severity: "good" | "warning" | "critical";
+  headline: string;
+  bullets: string[];
+};
+
+type HookState = {
+  loading: boolean;
+  source: InsightSource;
+  error: string | null;
+  insights: ProjectInsights | null;
+  highlight: HighlightSummary | null;
+};
+
+const initialState: HookState = {
+  loading: false,
+  source: "idle",
+  error: null,
+  insights: null,
+  highlight: null,
+};
+
+function deriveHighlight(insights: ProjectInsights): HighlightSummary {
+  const {
+    metrics: {
+      evm: { cpi, spi, costVariance, scheduleVariance },
+      risks,
+    },
+    timeline,
+  } = insights;
+
+  const bullets: string[] = [];
+  let severity: HighlightSummary["severity"] = "good";
+
+  if (timeline.chatSummary) {
+    bullets.push(timeline.chatSummary);
+  }
+
+  const cpiRounded = Number(cpi.toFixed(2));
+  const spiRounded = Number(spi.toFixed(2));
+  bullets.push(`CPI: ${cpiRounded} / SPI: ${spiRounded}`);
+
+  if (cpiRounded < 1 || spiRounded < 1) {
+    severity = cpiRounded < 0.95 || spiRounded < 0.9 ? "critical" : "warning";
+  } else if (cpiRounded >= 1.05 && spiRounded >= 1.05) {
+    bullets.push("コスト効率と進捗が計画を上回っています。");
+  }
+
+  if (scheduleVariance < 0) {
+    bullets.push(`スケジュール遅延: ${Math.abs(scheduleVariance).toLocaleString()} 円相当の遅れ`);
+    severity = severity === "good" ? "warning" : severity;
+  } else if (scheduleVariance > 0) {
+    bullets.push("スケジュールは前倒しで進行しています。");
+  }
+
+  if (costVariance < 0) {
+    bullets.push("コストが計画を上回っています。追加の原価精査が必要です。");
+    severity = "warning";
+  }
+
+  const highRisks = risks.filter((risk) => risk.probability >= 4 && risk.impact >= 4);
+  if (highRisks.length > 0) {
+    highRisks.forEach((risk) => {
+      bullets.push(`高リスク (${risk.status}) — 影響:${risk.impact}/確率:${risk.probability}`);
+    });
+    severity = "critical";
+  } else if (risks.length > 0) {
+    bullets.push(`リスク登録件数: ${risks.length} 件`);
+  }
+
+  const headline =
+    severity === "critical"
+      ? "⚠️ 重要なリスクと遅延に注意が必要です"
+      : severity === "warning"
+        ? "⚠️ 軽微な遅延やコスト超過が発生しています"
+        : "✅ 計画どおりに進行しています";
+
+  return { severity, headline, bullets: Array.from(new Set(bullets)) };
+}
+
+async function fetchFromGraphQL(projectId: string) {
+  const data = await graphqlRequest<{ timeline: ProjectTimeline; metrics: ProjectMetrics }>({
+    query: PROJECT_INSIGHTS_QUERY,
+    variables: { projectId },
+  });
+  return {
+    data: { timeline: data.timeline, metrics: data.metrics } satisfies ProjectInsights,
+    source: "graphql" as const,
+  };
+}
+
+async function fetchFromRest(projectId: string) {
+  const [timeline, metrics] = await Promise.all([
+    apiRequest<ProjectTimeline>({ path: `/api/v1/projects/${projectId}/timeline` }),
+    apiRequest<ProjectMetrics>({ path: `/api/v1/projects/${projectId}/metrics` }),
+  ]);
+  return {
+    data: { timeline, metrics } satisfies ProjectInsights,
+    source: "rest" as const,
+  };
+}
+
+export function useProjectInsights(projectId: string | null) {
+  const [state, setState] = useState<HookState>(initialState);
+  const projectRef = useRef<string | null>(projectId);
+
+  const executeFetch = useCallback(async () => {
+    if (!projectId) {
+      setState(initialState);
+      projectRef.current = null;
+      return;
+    }
+    projectRef.current = projectId;
+    setState((prev) => ({ ...prev, loading: true, error: null, source: prev.source === "idle" ? "idle" : prev.source }));
+
+    const computeResult = (insights: ProjectInsights, source: InsightSource) => {
+      const highlight = deriveHighlight(insights);
+      setState({
+        loading: false,
+        error: null,
+        insights,
+        highlight,
+        source,
+      });
+    };
+
+    try {
+      const { data, source } = await fetchFromGraphQL(projectId);
+      computeResult(data, source);
+      return;
+    } catch (graphErr) {
+      console.warn("[project-insights] GraphQL fetch failed", graphErr);
+    }
+
+    try {
+      const { data, source } = await fetchFromRest(projectId);
+      computeResult(data, source);
+      return;
+    } catch (restErr) {
+      console.warn("[project-insights] REST fallback failed", restErr);
+    }
+
+    const mock = getMockProjectInsights(projectId);
+    computeResult(mock, "mock");
+  }, [projectId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      await executeFetch();
+    };
+    run().catch((error) => {
+      if (cancelled) {
+        return;
+      }
+      console.error("[project-insights] unexpected error", error);
+      const mock = projectId ? getMockProjectInsights(projectId) : null;
+      setState({
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+        insights: mock,
+        highlight: mock ? deriveHighlight(mock) : null,
+        source: mock ? "mock" : "idle",
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [executeFetch, projectId]);
+
+  const refresh = useCallback(() => {
+    void executeFetch();
+  }, [executeFetch]);
+
+  const burndownTrend = useMemo(() => {
+    const series: BurndownSeries | undefined = state.insights?.metrics?.burndown;
+    if (!series) {
+      return null;
+    }
+    const lastActual = series.actual.at(-1);
+    const lastPlanned = series.planned.at(-1);
+    if (lastActual == null || lastPlanned == null) {
+      return null;
+    }
+    const delta = lastActual - lastPlanned;
+    if (Math.abs(delta) < 5) {
+      return "on-track";
+    }
+    return delta > 0 ? "behind" : "ahead";
+  }, [state.insights]);
+
+  return {
+    ...state,
+    refresh,
+    burndownTrend,
+  };
+}


### PR DESCRIPTION
## Summary
- add ProjectInsightsPanel with AIハイライト/EVM/リスク統合表示
- implement GraphQL+REST fallback hook and mock data for insights
- update Playwright e2e, docs/projects/project-dashboard.md, and navigation links

## Issue
- closes #279

## Testing
- cd ui-poc && npx playwright test tests/e2e/projects.spec.ts