### PR TITLE
feat: add billing replay and monitoring

### DIFF
--- a/.github/workflows/billing-nightly.yml
+++ b/.github/workflows/billing-nightly.yml
@@ -1,0 +1,23 @@
+name: Billing Pipeline Dry Run
+
+on:
+  schedule:
+    - cron: '0 21 * * *'
+  workflow_dispatch:
+
+jobs:
+  replay-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Dry run invoice replay
+        run: |
+          node scripts/billing/replay-invoice.js \
+            --project nightly-check \
+            --code NIGHTLY-CHECK \
+            --event SIGNED \
+            --base-url ${PROJECT_API_BASE:-http://localhost:3000} \
+            --dry-run

--- a/.github/workflows/terraform-compliance.yml
+++ b/.github/workflows/terraform-compliance.yml
@@ -9,9 +9,16 @@ on:
 jobs:
   terraform:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - stack: electronic-ledger
+            workdir: iac/stacks/electronic-ledger
+          - stack: billing-monitoring
+            workdir: iac/stacks/billing-monitoring
     defaults:
       run:
-        working-directory: iac/stacks/electronic-ledger
+        working-directory: ${{ matrix.workdir }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
@@ -23,7 +30,8 @@ jobs:
         run: terraform init
       - name: Terraform validate
         run: terraform validate
-      - name: Terraform plan
+      - name: Terraform plan (electronic-ledger)
+        if: matrix.stack == 'electronic-ledger'
         env:
           TF_VAR_aws_region: ap-northeast-1
           TF_VAR_ledger_bucket_name: demo-ledger-bucket
@@ -34,4 +42,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: dummy
           AWS_DEFAULT_REGION: ap-northeast-1
           TF_VAR_environment: ci
+        run: terraform plan -input=false -lock=false
+      - name: Terraform plan (billing-monitoring)
+        if: matrix.stack == 'billing-monitoring'
+        env:
+          TF_VAR_aws_region: ap-northeast-1
+          TF_VAR_environment: ci
+          TF_VAR_skip_credentials_validation: "true"
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+          AWS_DEFAULT_REGION: ap-northeast-1
         run: terraform plan -input=false -lock=false

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@
 
 ## CLI ユーティリティ
 - [Projects Slack 共有 CLI ガイド](projects-share-cli.md)
+- `scripts/notifications/send-summary.js` — 要約検索結果を Slack へ通知する CLI（Runbook 参照）
+- `scripts/billing/replay-invoice.js` — 請求書生成ジョブを再実行する CLI
 
 ## API Examples
 - [Projects 一覧のページネーション例](api-projects-pagination.md)

--- a/docs/contracts/invoice-pipeline.md
+++ b/docs/contracts/invoice-pipeline.md
@@ -21,7 +21,32 @@ curl -X POST http://localhost:3000/billing/contracts/events \
     "contractCode": "DEMO-001",
     "customerEmail": "billing@example.com"
   }'
+
+# 失敗後にバックフィル実行
+node scripts/billing/replay-invoice.js \
+  --project demo-001 \
+  --code DEMO-001 \
+  --event SIGNED \
+  --base-url http://localhost:3000 \
+  --dry-run
 ```
 
 - `INVOICE_OUTPUT_DIR` (既定 `logs/invoices`) に PDF/HTML が生成されます。
 - S3 / SES を利用する場合は `.env` に対応する環境変数を設定してください。
+
+## 監視とアラート
+- Datadog: `billing.invoice.success`, `billing.invoice.failure`, `billing.invoice.duration_ms`, `billing.invoice.email.success`
+- CloudWatch (新規モジュール `iac/modules/billing-monitoring`):
+  - Invoice Failure Alarm (`BillingInvoiceFailure`)
+  - DocuSign Webhook Error Alarm (`DocuSignWebhookError`)
+  - ダッシュボード `billing-invoice-operations`
+
+## 障害対応
+1. **DocuSign webhook 失敗**: CloudWatch アラーム発火 → 再試行 (Webhook 再送 or CLI `replay-invoice`).
+2. **請求ジョブ失敗**: Datadog メトリクス `billing.invoice.failure` を確認し、`scripts/billing/replay-invoice.js` でリプレイ。
+3. **メール送信失敗**: `billing.invoice.email.success` が上がらない場合、SES 権限や送信未認証アドレスを確認。
+4. **S3 保存失敗**: CloudWatch Logs で `aws:s3` エラーを確認、`INVOICE_OUTPUT_DIR` にフォールバックしているか確認。
+
+Runbook の当番手順:
+- 失敗イベントが Slack に通知された場合、`replay-invoice.js --dry-run` でペイロードを確認し再送。
+- 連続失敗時は `INVOICE_OUTPUT_DIR` にエラーログ (`invoice-processor` logger) が出力されるので確認。

--- a/iac/modules/billing-monitoring/main.tf
+++ b/iac/modules/billing-monitoring/main.tf
@@ -1,0 +1,85 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  tags = {
+    Environment = var.environment
+    Service     = var.service_name
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "invoice_failures" {
+  alarm_name          = "billing-invoice-failure-${var.environment}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "BillingInvoiceFailure"
+  namespace           = "ProjectAPI/Billing"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "Triggered when invoice processing fails"
+  alarm_actions       = var.alarm_topics
+  ok_actions          = var.alarm_topics
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "webhook_errors" {
+  alarm_name          = "billing-webhook-error-${var.environment}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "DocuSignWebhookError"
+  namespace           = "ProjectAPI/Billing"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  alarm_description   = "Triggered when DocuSign webhook handler fails"
+  alarm_actions       = var.alarm_topics
+  ok_actions          = var.alarm_topics
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_dashboard" "billing" {
+  dashboard_name = var.dashboard_name
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type = "metric"
+        width = 12
+        height = 6
+        properties = {
+          view   = "timeSeries"
+          region = var.aws_region
+          title  = "Billing Invoice Success / Failure"
+          metrics = [
+            ["ProjectAPI/Billing", "billing.invoice.success", { "stat" : "Sum", "label" : "Success" }],
+            ["ProjectAPI/Billing", "billing.invoice.failure", { "stat" : "Sum", "label" : "Failure" }],
+          ]
+          period = 300
+          stacked = false
+        }
+      },
+      {
+        type = "metric"
+        width = 12
+        height = 6
+        properties = {
+          view   = "timeSeries"
+          region = var.aws_region
+          title  = "DocuSign Webhook Errors"
+          metrics = [
+            ["ProjectAPI/Billing", "DocuSignWebhookError", { "stat" : "Sum" }],
+          ]
+          period = 300
+        }
+      }
+    ]
+  })
+}

--- a/iac/modules/billing-monitoring/outputs.tf
+++ b/iac/modules/billing-monitoring/outputs.tf
@@ -1,0 +1,14 @@
+output "invoice_alarm_name" {
+  value       = aws_cloudwatch_metric_alarm.invoice_failures.alarm_name
+  description = "Name of the invoice failure alarm"
+}
+
+output "webhook_alarm_name" {
+  value       = aws_cloudwatch_metric_alarm.webhook_errors.alarm_name
+  description = "Name of the DocuSign webhook alarm"
+}
+
+output "dashboard_name" {
+  value       = aws_cloudwatch_dashboard.billing.dashboard_name
+  description = "CloudWatch dashboard name"
+}

--- a/iac/modules/billing-monitoring/variables.tf
+++ b/iac/modules/billing-monitoring/variables.tf
@@ -1,0 +1,28 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "alarm_topics" {
+  description = "SNS topics for alarm notifications"
+  type        = list(string)
+  default     = []
+}
+
+variable "environment" {
+  description = "Deployment environment tag (e.g., prod, qa)"
+  type        = string
+  default     = "sandbox"
+}
+
+variable "service_name" {
+  description = "Service tag value"
+  type        = string
+  default     = "project-api"
+}
+
+variable "dashboard_name" {
+  description = "CloudWatch dashboard name"
+  type        = string
+  default     = "billing-invoice-operations"
+}

--- a/iac/stacks/billing-monitoring/README.md
+++ b/iac/stacks/billing-monitoring/README.md
@@ -1,0 +1,17 @@
+# Billing Monitoring Stack
+
+Usage:
+
+```bash
+cd iac/stacks/billing-monitoring
+cp ../electronic-ledger/backend.hcl.example backend.hcl
+terraform init -backend-config=backend.hcl
+terraform plan -var="aws_region=ap-northeast-1" \
+  -var="environment=qa" \
+  -var='alarm_topics=["arn:aws:sns:ap-northeast-1:123456789012:billing-alerts"]'
+```
+
+Outputs:
+- `invoice_alarm_name`
+- `webhook_alarm_name`
+- `dashboard_name`

--- a/iac/stacks/billing-monitoring/backend.hcl.example
+++ b/iac/stacks/billing-monitoring/backend.hcl.example
@@ -1,0 +1,3 @@
+bucket  = "my-terraform-state"
+key     = "billing-monitoring/terraform.tfstate"
+region  = "ap-northeast-1"

--- a/iac/stacks/billing-monitoring/main.tf
+++ b/iac/stacks/billing-monitoring/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region                      = var.aws_region
+  skip_credentials_validation = var.skip_credentials_validation
+  skip_metadata_api_check     = var.skip_credentials_validation
+  skip_region_validation      = var.skip_credentials_validation
+  skip_requesting_account_id  = var.skip_credentials_validation
+}
+
+module "billing_monitoring" {
+  source         = "../../modules/billing-monitoring"
+  aws_region     = var.aws_region
+  alarm_topics   = var.alarm_topics
+  environment    = var.environment
+  service_name   = var.service_name
+  dashboard_name = var.dashboard_name
+}

--- a/iac/stacks/billing-monitoring/outputs.tf
+++ b/iac/stacks/billing-monitoring/outputs.tf
@@ -1,0 +1,11 @@
+output "invoice_alarm_name" {
+  value = module.billing_monitoring.invoice_alarm_name
+}
+
+output "webhook_alarm_name" {
+  value = module.billing_monitoring.webhook_alarm_name
+}
+
+output "dashboard_name" {
+  value = module.billing_monitoring.dashboard_name
+}

--- a/iac/stacks/billing-monitoring/variables.tf
+++ b/iac/stacks/billing-monitoring/variables.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "alarm_topics" {
+  description = "SNS topics for alarm notifications"
+  type        = list(string)
+  default     = []
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "sandbox"
+}
+
+variable "service_name" {
+  description = "Service tag"
+  type        = string
+  default     = "project-api"
+}
+
+variable "dashboard_name" {
+  description = "CloudWatch dashboard name"
+  type        = string
+  default     = "billing-invoice-operations"
+}
+
+variable "skip_credentials_validation" {
+  description = "Skip AWS credential checks (useful for CI)"
+  type        = bool
+  default     = false
+}

--- a/scripts/billing/replay-invoice.js
+++ b/scripts/billing/replay-invoice.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+const http = require('node:http');
+const https = require('node:https');
+const { URL } = require('node:url');
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.PROJECT_API_BASE || 'http://localhost:3000',
+    eventType: 'SIGNED',
+    dryRun: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    const next = argv[i + 1];
+    switch (token) {
+      case '--project':
+      case '-p':
+        options.contractId = next;
+        i += 1;
+        break;
+      case '--code':
+      case '-c':
+        options.contractCode = next;
+        i += 1;
+        break;
+      case '--event':
+      case '-e':
+        options.eventType = next;
+        i += 1;
+        break;
+      case '--customer-email':
+        options.customerEmail = next;
+        i += 1;
+        break;
+      case '--base-url':
+      case '-b':
+        options.baseUrl = next;
+        i += 1;
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: replay-invoice --project <id> --code <code> [options]\n\nOptions:\n  --project, -p        Contract ID (required)\n  --code, -c           Contract code (required)\n  --event, -e          Event type (default SIGNED)\n  --customer-email     Optional recipient email\n  --base-url, -b       API base URL (default http://localhost:3000)\n  --dry-run            Show payload without POST\n  --help               Show this help\n`);
+}
+
+async function postJson(url, body) {
+  const target = new URL(url);
+  const payload = Buffer.from(JSON.stringify(body));
+  const requestOptions = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': payload.length,
+    },
+  };
+  const client = target.protocol === 'https:' ? https : http;
+  return new Promise((resolve, reject) => {
+    const req = client.request(target, requestOptions, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('error', reject);
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf-8');
+        if (res.statusCode && res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode}: ${text}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(text));
+        } catch {
+          resolve(text);
+        }
+      });
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+(async () => {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!options.contractId || !options.contractCode) {
+    console.error('Error: --project and --code are required');
+    printHelp();
+    process.exit(1);
+  }
+
+  const payload = {
+    contractId: options.contractId,
+    contractCode: options.contractCode,
+    eventType: options.eventType,
+    customerEmail: options.customerEmail,
+  };
+
+  if (options.dryRun) {
+    console.log('[dry-run] POST', `${options.baseUrl.replace(/\/$/, '')}/billing/contracts/replay`);
+    console.log(JSON.stringify(payload, null, 2));
+    process.exit(0);
+  }
+
+  try {
+    const response = await postJson(`${options.baseUrl.replace(/\/$/, '')}/billing/contracts/replay`, payload);
+    console.log('Replay response:', response);
+  } catch (error) {
+    console.error('[replay-invoice] failed:', error.message);
+    process.exit(1);
+  }
+})();

--- a/services/project-api/src/billing/billing.module.ts
+++ b/services/project-api/src/billing/billing.module.ts
@@ -5,10 +5,11 @@ import { DocuSignWebhookController } from './docusign.controller';
 import { InvoiceQueueService } from './invoice-queue.service';
 import { InvoiceProcessorService } from './invoice-processor.service';
 import { ContractAutomationService } from './contract-automation.service';
+import { DatadogMetricsService } from '../monitoring/datadog.service';
 
 @Module({
   imports: [ConfigModule],
-  providers: [InvoiceQueueService, InvoiceProcessorService, ContractAutomationService],
+  providers: [InvoiceQueueService, InvoiceProcessorService, ContractAutomationService, DatadogMetricsService],
   controllers: [BillingController, DocuSignWebhookController],
   exports: [ContractAutomationService, InvoiceQueueService],
 })

--- a/services/project-api/src/billing/contract-events.controller.ts
+++ b/services/project-api/src/billing/contract-events.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post } from '@nestjs/common';
 import type { ContractEventPayload } from '../../../../shared/contracts/lifecycle';
 import { ContractAutomationService } from './contract-automation.service';
 import { InvoiceQueueService } from './invoice-queue.service';
+import { ReplayInvoiceDto } from './dto/replay.dto';
 
 @Controller('billing/contracts')
 export class BillingController {
@@ -12,5 +13,17 @@ export class BillingController {
     await this.automation.handleContractEvent(payload);
     await this.queue.waitForIdle();
     return { status: 'accepted' };
+  }
+
+  @Post('replay')
+  async replay(@Body() payload: ReplayInvoiceDto) {
+    await this.automation.enqueueInvoiceJob({
+      contractId: payload.contractId,
+      contractCode: payload.contractCode,
+      type: payload.eventType,
+      customerEmail: payload.customerEmail,
+    });
+    await this.queue.waitForIdle();
+    return { status: 'replayed' };
   }
 }

--- a/services/project-api/src/billing/dto/replay.dto.ts
+++ b/services/project-api/src/billing/dto/replay.dto.ts
@@ -1,0 +1,27 @@
+import { ContractEventPayload } from '../../../../../shared/contracts/lifecycle';
+import { IsEmail, IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export enum ReplayEventType {
+  ISSUED = 'ISSUED',
+  SIGNED = 'SIGNED',
+  ACTIVATED = 'ACTIVATED',
+  RENEWED = 'RENEWED',
+  TERMINATED = 'TERMINATED',
+}
+
+export class ReplayInvoiceDto {
+  @IsString()
+  @MaxLength(120)
+  contractId!: string;
+
+  @IsString()
+  @MaxLength(120)
+  contractCode!: string;
+
+  @IsEnum(ReplayEventType)
+  eventType!: ContractEventPayload['type'];
+
+  @IsOptional()
+  @IsEmail()
+  customerEmail?: string;
+}

--- a/services/project-api/test/contract-invoice.e2e.spec.ts
+++ b/services/project-api/test/contract-invoice.e2e.spec.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 import request from 'supertest';
 import { AppModule } from '../src/app.module';
+import { InvoiceProcessorService } from '../src/billing/invoice-processor.service';
 
 describe('Contract Invoice Pipeline (e2e)', () => {
   let app: INestApplication;
@@ -47,5 +48,48 @@ describe('Contract Invoice Pipeline (e2e)', () => {
     const htmlExists = files.some((file) => file.isFile() && file.name.endsWith('.html'));
     expect(pdfExists).toBe(true);
     expect(htmlExists).toBe(true);
+  });
+
+  it('replays invoice job when initial processing fails', async () => {
+    const processor = app.get(InvoiceProcessorService);
+    const originalProcess = processor.process.bind(processor);
+    let fail = true;
+    const spy = jest
+      .spyOn(processor, 'process')
+      .mockImplementation(async (job) => {
+        if (fail) {
+          fail = false;
+          throw new Error('forced failure');
+        }
+        return originalProcess(job);
+      });
+
+    const payload = {
+      type: 'SIGNED',
+      occurredAt: new Date().toISOString(),
+      triggeredBy: 'automation@test',
+      contractId: 'contract-test-2',
+      contractCode: 'CONTRACT-TEST-2',
+      metadata: { source: 'test' },
+    };
+
+    try {
+      await request(app.getHttpServer()).post('/billing/contracts/events').send(payload).expect(500);
+      await request(app.getHttpServer())
+        .post('/billing/contracts/replay')
+        .send({
+          contractId: payload.contractId,
+          contractCode: payload.contractCode,
+          eventType: 'SIGNED',
+        })
+        .expect(201)
+        .expect({ status: 'replayed' });
+
+      const files = await fs.readdir(path.join(outputDir, payload.contractCode), { withFileTypes: true }).catch(() => []);
+      const pdfExists = files.some((file) => file.isFile() && file.name.endsWith('.pdf'));
+      expect(pdfExists).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add replay endpoint and CLI for invoice jobs with Datadog metrics
- provision CloudWatch monitoring stack and nightly dry-run workflow
- extend Runbook/docs and e2e tests for failure replay scenario

## Issue
- closes #281

## Testing
- cd services/project-api && npm run test
- ./scripts/generate-api-docs.sh