### PR TITLE
chore: follow-up ops tasks

### DIFF
--- a/.github/workflows/ui-poc-e2e.yml
+++ b/.github/workflows/ui-poc-e2e.yml
@@ -1,0 +1,37 @@
+name: UI PoC E2E
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+
+jobs:
+  e2e-mock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: ui-poc
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: ui-poc
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests (mock mode)
+        env:
+          E2E_EXPECT_API: 'false'
+        working-directory: ui-poc
+        run: npx playwright test --reporter=dot
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-poc-e2e-report
+          path: ui-poc/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo "  make test-e2e                # Run UI Playwright E2E tests"
 	@echo "  make share-projects          # Generate Projects Slack share template (ARGS="..." to pass options)"
 	@echo "  make share-projects-sample   # Output sample Projects Slack share template"
+	@echo "  make ledger-plan             # Run terraform plan for electronic-ledger stack (skip creds)"
 
 .PHONY: live-tests
 live-tests:
@@ -38,3 +39,16 @@ share-projects:
 .PHONY: share-projects-sample
 share-projects-sample:
 	cd ui-poc && npm run --silent share:projects:sample
+
+.PHONY: ledger-plan
+ledger-plan:
+	@cd iac/stacks/electronic-ledger && \
+	tmp=$$(mktemp -d) && \
+	curl -fsSLo $$tmp/terraform.zip https://releases.hashicorp.com/terraform/1.9.0/terraform_1.9.0_linux_amd64.zip && \
+	unzip -q $$tmp/terraform.zip -d $$tmp && \
+	"$$tmp/terraform" init -backend=false >/dev/null && \
+	TF_VAR_aws_region=ap-northeast-1 \
+	TF_VAR_environment=ci \
+	TF_VAR_skip_credentials_validation=true \
+	AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy AWS_DEFAULT_REGION=ap-northeast-1 \
+	"$$tmp/terraform" plan -input=false -lock=false

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,10 +21,10 @@
 ## CLI ユーティリティ
 - [Projects Slack 共有 CLI ガイド](projects-share-cli.md)
 - `scripts/notifications/send-summary.js` — 要約検索結果を Slack へ通知する CLI（Runbook 参照）
-<<<<<<< HEAD
-=======
 - `scripts/billing/replay-invoice.js` — 請求書生成ジョブを再実行する CLI
->>>>>>> origin/main
+
+## UI Testing
+- GitHub Actions: `UI PoC E2E`（mock モード Playwright を夜間実行）
 
 ## API Examples
 - [Projects 一覧のページネーション例](api-projects-pagination.md)

--- a/docs/compliance/electronic-ledger-runbook.md
+++ b/docs/compliance/electronic-ledger-runbook.md
@@ -5,9 +5,29 @@ S3 Object Lock + KMS + DynamoDB を利用した電子帳簿法（WORM）準拠�
 
 ## 手順概要
 1. `iac/stacks/electronic-ledger/backend.tf.example` と `backend.hcl.example` をコピーし、S3 バケット / DynamoDB テーブルを設定
-2. `terraform init -backend-config=backend.hcl` を実行して初期化
-3. `terraform plan` で差分を確認
-4. `terraform apply` で本番 / QA 環境へデプロイ
+2. `terraform.tfvars` に環境変数を定義（例を後述）
+3. `terraform init -backend-config=backend.hcl` を実行して初期化
+4. `terraform plan` で差分を確認（`make ledger-plan` で Dry-run 可）
+5. `terraform apply` で本番 / QA 環境へデプロイ
+
+### `terraform.tfvars` サンプル
+```hcl
+aws_region             = "ap-northeast-1"
+ledger_bucket_name     = "prod-electronic-ledger"
+aws_account_id         = "123456789012"
+account_admin_arn      = "arn:aws:iam::123456789012:role/SecurityAdmin"
+alarm_topics           = ["arn:aws:sns:ap-northeast-1:123456789012:security-alerts"]
+tags = {
+  Owner       = "compliance-team"
+  CostCenter  = "FIN-OPS"
+}
+```
+
+### Dry-run
+```
+make ledger-plan
+```
+CI と同じ `skip_credentials_validation=true` の設定で `terraform plan` が実行されます。
 
 ## バケット構成
 - バージョニング + Object Lock (COMPLIANCE モード)

--- a/docs/monitoring/chat-summarizer-dashboard.json
+++ b/docs/monitoring/chat-summarizer-dashboard.json
@@ -1,0 +1,93 @@
+{
+  "widgets": [
+    {
+      "definition": {
+        "title": "Chat Summarizer Success vs Failure",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "horizontal",
+        "legend_columns": ["avg", "last", "min", "max"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "sum:chat_summarizer.success{*} by {environment}",
+            "display_type": "line",
+            "name": "Success"
+          },
+          {
+            "q": "sum:chat_summarizer.failure{*} by {environment}",
+            "display_type": "line",
+            "name": "Failure"
+          }
+        ],
+        "yaxis": {
+          "scale": "linear"
+        }
+      },
+      "layout": {
+        "x": 0,
+        "y": 0,
+        "width": 47,
+        "height": 16
+      }
+    },
+    {
+      "definition": {
+        "title": "Retry Attempts",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "sum:chat_summarizer.retry_exhausted{*} by {environment}",
+            "aggregator": "sum"
+          }
+        ],
+        "autoscale": true
+      },
+      "layout": {
+        "x": 0,
+        "y": 16,
+        "width": 23,
+        "height": 8
+      }
+    },
+    {
+      "definition": {
+        "title": "Average Duration (ms)",
+        "type": "query_value",
+        "requests": [
+          {
+            "q": "avg:chat_summarizer.duration_ms{*} by {environment}",
+            "aggregator": "avg"
+          }
+        ],
+        "autoscale": true
+      },
+      "layout": {
+        "x": 24,
+        "y": 16,
+        "width": 23,
+        "height": 8
+      }
+    },
+    {
+      "definition": {
+        "title": "Search Success Rate",
+        "type": "timeseries",
+        "requests": [
+          {
+            "q": "100 * sum:chat_summarizer.search.success{*} / (sum:chat_summarizer.search.success{*} + sum:chat_summarizer.search.error{*})",
+            "display_type": "line",
+            "name": "Search Success %"
+          }
+        ]
+      },
+      "layout": {
+        "x": 0,
+        "y": 24,
+        "width": 47,
+        "height": 12
+      }
+    }
+  ]
+}

--- a/docs/projects/chat-summary-runbook.md
+++ b/docs/projects/chat-summary-runbook.md
@@ -46,9 +46,17 @@ node scripts/notifications/send-summary.js \
 - Webhook URL が無効 (HTTP 410) の場合は再発行。
 - Payload サイズ (40KB) 超過に注意。結果件数を `--top 3` などで縮小。
 
-## 監視メトリクス
-- `chat_summarizer.search.success` / `chat_summarizer.search.error`
-- Nightly CLI 実行結果 (予定): GitHub Actions の exit code でモニタリング。
+## 監視メトリクス / SLA
+- Datadog ダッシュボード (import: `docs/monitoring/chat-summarizer-dashboard.json`)
+  - `chat_summarizer.success` vs `chat_summarizer.failure`
+  - `chat_summarizer.retry_exhausted`
+  - `chat_summarizer.duration_ms` 平均
+  - 検索成功率 `chat_summarizer.search.success` / `chat_summarizer.search.error`
+- SLA 目標
+  - 要約成功率: 99% 以上 (5分平均)
+  - 検索成功率: 97% 以上
+  - リトライ枯渇 (`retry_exhausted`) が 5 分間に 3 回連続発生したら当番に通知
+- Nightly CLI (GitHub Actions) で Slack 通知の乾式実行を継続監視。
 
 ## 関連資料
 - [Project Dashboard (AI ハイライト)](project-dashboard.md)


### PR DESCRIPTION
## Summary
- add Datadog dashboard template for ChatSummarizer SLA and update Runbook thresholds
- extend electronic-ledger Runbook with terraform.tfvars example and make helper
- add nightly UI PoC Playwright workflow for regression coverage

## Issue
- addresses #282

## Testing
- make ledger-plan
- ./scripts/generate-api-docs.sh
