### PR TITLE
feat: phase3 crm & sales implementation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 
 ## Runbooks
 - [HR Ops Runbook](runbooks/hr-ops.md)
+- [CRM / Sales リリース手順](runbooks/crm-sales-release.md)
 
 ## Live Testing
 - [Live Testing Guide](live-testing.md)

--- a/docs/runbooks/crm-sales-release.md
+++ b/docs/runbooks/crm-sales-release.md
@@ -1,0 +1,28 @@
+# CRM / Sales モジュール リリース手順
+
+Phase3 本実装に合わせて CRM / Sales モジュールを本番適用するためのチェックリストです。対象リポジトリ: `services/project-api`。
+
+## 1. 事前準備
+- [ ] `DATABASE_URL` を本番 PostgreSQL に向け、Prisma マイグレーション (`20251014164013_phase3_crm_sales_init`) を適用
+- [ ] Seed データで作成されるサンプル顧客/見積データが不要な場合は無効化または削除
+- [ ] `api/v1/crm`・`api/v1/sales` REST エンドポイントをステージングで疎通確認 (`GET /quotes`, `POST /orders` など)
+- [ ] GraphQL スキーマ差分を `npx graphql-codegen`（将来導入予定）または `npm run lint` で確認
+
+## 2. リリース手順
+1. `npm run lint` / `npm run test -- --testPathPattern=src/hr --passWithNoTests` を実行し、CI と同等のカバレッジを通過させる
+2. `DATABASE_URL` を本番環境の接続文字列に設定し、`npx prisma migrate deploy` を実行
+3. `scripts/ci/run-codex-template-smoke.sh` を実行し、新テンプレートのテンプレ生成が成功することを確認
+4. `api/v1/crm/customers` と `api/v1/sales/quotes` を `curl` で実行し、200 応答と想定データが返ることを確認
+5. Slack `#sales-ops` へリリース開始を通知し、Credit Review の承認フロー手順を共有
+
+## 3. ロールバック
+- [ ] リリース後 60 分以内の障害は `npx prisma migrate resolve --rolled-back` を利用して直近マイグレーションをロールバック
+- [ ] CloudWatch ダッシュボード (`sales-overview-<env>`) のアラームが連続発報した場合は `orderAuditLog` を参照して状態復元
+- [ ] REST エンドポイントに障害がある場合は API Gateway / ALB で旧バージョンへ切り戻し
+
+## 4. コミュニケーション
+- [ ] リリース完了後に Slack `#product-ai`、`#sales-ops` へ展開完了と KPI 影響を共有
+- [ ] 重大な仕様変更は Confluence / Notion のモジュールまとめページを更新
+
+---
+最終更新: 2025-10-14 / Maintainer: AI Platform Engineering

--- a/docs/specs/crm/requirements.md
+++ b/docs/specs/crm/requirements.md
@@ -12,11 +12,11 @@ Issue #295 / #159 に基づき、Phase2 で実装する CRM モジュールの�
 ## 2. エンティティとリレーション
 | エンティティ | 主な属性 | 備考 |
 |--------------|----------|------|
-| Customer | id, name, type, industry, ownerUserId, tags[] | 法人／個人双方を扱えるスキーマ |
+| Customer | id, name, type, industry, ownerUserId, tagsJson | タグは JSON 文字列（SQLite 互換）。本番では pgvector + JSONB へ移行予定 |
 | Contact | id, customerId, name, role, email, phone | 顧客担当者。Slack/Meet 等の識別子も保持 |
 | Opportunity | id, customerId, title, stage, amount, expectedClose | 案件フェーズ（Lead/Qualified/Proposal/Negotiation/Won/Lost） |
 | InteractionNote | id, customerId, contactId?, occurredAt, channel, rawText | 会話ログの原文保存。要約は AI 側で付随 |
-| ConversationSummary | id, interactionId, embedding, summaryText, followupSuggested | LangGraph で生成した要約を保持 |
+| ConversationSummary | id, interactionId, embedding, summaryText, followupSuggestedJson | LangGraph で生成した要約。フォローアップは JSON 文字列で保持 |
 
 リレーション:
 - Customer 1 - n Contact / Opportunity / InteractionNote
@@ -38,11 +38,13 @@ createOpportunity(input: CreateOpportunityInput!): Opportunity!
 conversationSummaries(customerId: ID!, limit: Int = 20): [ConversationSummary!]
 ```
 
-REST エンドポイント（暫定）：
-- `GET /api/v1/crm/customers`
+REST エンドポイント：
+- `GET /api/v1/crm/customers` (search/type/industry クエリパラメータ対応)
 - `POST /api/v1/crm/customers`
-- `GET /api/v1/crm/opportunities`
+- `PATCH /api/v1/crm/customers/:id`
+- `GET /api/v1/crm/customers/:id/opportunities`
 - `POST /api/v1/crm/opportunities`
+- `POST /api/v1/crm/interaction-notes`
 
 ## 4. バリデーション / ビジネスルール
 - 顧客名 + 担当者の組合せで重複登録を防止
@@ -51,7 +53,7 @@ REST エンドポイント（暫定）：
 - ConversationSummary の followupSuggested は最大 5 件
 
 ## 5. 非機能要件
-- pgvector を利用して ConversationSummary.embedding を格納し、会話検索を最適化
+- pgvector を利用して ConversationSummary.embedding を格納し、会話検索を最適化（SQLite では TEXT, 本番は pgvector）
 - 監査ログ (customer.created/updated, opportunity.stageChanged) を既存監査ストリームへ発行
 - 1 分毎のバッチ連携（外部チャット統合）を想定し、API タイムアウトは 5 秒以下
 
@@ -65,8 +67,8 @@ REST エンドポイント（暫定）：
 
 ## 8. AI DevFlow バリデーション
 - Spec 作成 → `node scripts/templates/create-module.js --type nest-module --name crm --target services/project-api/src/crm`
-- プロジェクト全体の lint には既存検証エラーがあるため、`npx eslint src/crm` で新規モジュールの整合性を確認
-- `2025-10-14` 時点で CRM モジュール配下は lint OK。全体 lint の修正は別 Issue で追跡
+- `npx eslint src/crm src/sales` で新規モジュールの整合性を確認（プロジェクト全体 lint は別 Issue で追跡）
+- `2025-10-14` 時点で CRM / Sales モジュール配下は lint OK。全体 lint の修正は別 Issue で追跡
 
 ## 9. 未決事項
 - Customer スキーマのセグメント分類 (ARR/NRR) → Finance チームと連携予定

--- a/docs/specs/sales/requirements.md
+++ b/docs/specs/sales/requirements.md
@@ -11,11 +11,11 @@ Issue #296 / #159 の範囲として、見積・受注・与信フローをカ�
 ## 2. エンティティ
 | エンティティ | 主な属性 | 備考 |
 |--------------|----------|------|
-| Quote | id, quoteNumber, customerId, status, currency, totalAmount, validUntil | ステータス: Draft/PendingApproval/Approved/Rejected |
-| QuoteItem | id, quoteId, productCode, quantity, unitPrice, discountRate | 税込・税抜の2軸を保持 |
+| Quote | id, quoteNumber, customerId, status, currency, totalAmount, validUntil, version | ステータス: DRAFT/PENDING_APPROVAL/APPROVED/REJECTED |
+| QuoteItem | id, quoteId, productCode, quantity, unitPrice, discountRate | 金額は `REAL` (SQLite) / `NUMERIC(12,2)` (Postgres) |
 | Order | id, orderNumber, quoteId, status, signedAt, paymentTerm | ステータス: Pending/Fulfilled/Cancelled |
 | CreditReview | id, orderId, status, reviewerUserId, score, remarks | ステータス: Requested/Approved/Rejected |
-| OrderAuditLog | id, orderId, changeType, payload, createdAt | 電子帳簿法対象。改ざん防止ログに送信 |
+| OrderAuditLog | id, orderId, changeType, payload, createdAt, checksum | 電子帳簿法対象。payload は JSON 文字列、checksum で改ざん検知 |
 
 ## 3. API / GraphQL
 ```graphql
@@ -37,7 +37,7 @@ REST エンドポイント（初期案）:
 - `POST /api/v1/sales/orders/{id}/credit-review`
 
 ## 4. ビジネスルール
-- 見積の合計金額は QuoteItem の税込/税抜を双方保持し、受注変換時に税込金額を確定
+- 見積の合計金額は QuoteItem 単価・数量・割引率から算出し、Order 作成時に確定
 - 与信未承認の受注は請求モジュールへ伝播させない Feature Flag を導入
 - OrderAuditLog は KMS 署名付きで保存し、7 年保管
 - Quote → Order の変換で版履歴を残し、再承認が必要

--- a/services/project-api/prisma/migrations/20251014164013_phase3_crm_sales_init/migration.sql
+++ b/services/project-api/prisma/migrations/20251014164013_phase3_crm_sales_init/migration.sql
@@ -1,0 +1,157 @@
+-- CreateTable
+CREATE TABLE "Customer" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "externalId" TEXT,
+    "name" TEXT NOT NULL,
+    "type" TEXT NOT NULL DEFAULT 'CUSTOMER',
+    "industry" TEXT,
+    "ownerUserId" TEXT,
+    "tagsJson" TEXT NOT NULL DEFAULT '[]',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Contact" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "customerId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT,
+    "email" TEXT,
+    "phone" TEXT,
+    "slackUserId" TEXT,
+    "meetIdentity" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Contact_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Opportunity" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "customerId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "stage" TEXT NOT NULL DEFAULT 'LEAD',
+    "amount" REAL NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL DEFAULT 'JPY',
+    "expectedClose" DATETIME,
+    "ownerUserId" TEXT,
+    "stageEnteredAt" DATETIME DEFAULT CURRENT_TIMESTAMP,
+    "probability" INTEGER DEFAULT 0,
+    "statusReason" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Opportunity_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "InteractionNote" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "customerId" TEXT NOT NULL,
+    "contactId" TEXT,
+    "opportunityId" TEXT,
+    "occurredAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "channel" TEXT NOT NULL,
+    "rawText" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "InteractionNote_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "InteractionNote_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "Contact" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "InteractionNote_opportunityId_fkey" FOREIGN KEY ("opportunityId") REFERENCES "Opportunity" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ConversationSummary" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "interactionId" TEXT NOT NULL,
+    "summaryText" TEXT NOT NULL,
+    "followupSuggestedJson" TEXT NOT NULL DEFAULT '[]',
+    "embedding" BLOB,
+    "confidence" REAL NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ConversationSummary_interactionId_fkey" FOREIGN KEY ("interactionId") REFERENCES "InteractionNote" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Quote" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "quoteNumber" TEXT NOT NULL,
+    "customerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "currency" TEXT NOT NULL DEFAULT 'JPY',
+    "totalAmount" REAL NOT NULL DEFAULT 0,
+    "validUntil" DATETIME,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "submittedAt" DATETIME,
+    "approvedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Quote_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "QuoteItem" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "quoteId" TEXT NOT NULL,
+    "productCode" TEXT NOT NULL,
+    "description" TEXT,
+    "quantity" INTEGER NOT NULL,
+    "unitPrice" REAL NOT NULL DEFAULT 0,
+    "discountRate" REAL NOT NULL DEFAULT 0,
+    CONSTRAINT "QuoteItem_quoteId_fkey" FOREIGN KEY ("quoteId") REFERENCES "Quote" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "Order" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "orderNumber" TEXT NOT NULL,
+    "quoteId" TEXT NOT NULL,
+    "customerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "signedAt" DATETIME,
+    "paymentTerm" TEXT NOT NULL,
+    "totalAmount" REAL NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Order_quoteId_fkey" FOREIGN KEY ("quoteId") REFERENCES "Quote" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Order_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "CreditReview" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "orderId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'REQUESTED',
+    "reviewerUserId" TEXT,
+    "score" REAL,
+    "remarks" TEXT,
+    "requestedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "decidedAt" DATETIME,
+    CONSTRAINT "CreditReview_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "OrderAuditLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "orderId" TEXT NOT NULL,
+    "changeType" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "checksum" TEXT NOT NULL,
+    CONSTRAINT "OrderAuditLog_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Customer_externalId_key" ON "Customer"("externalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConversationSummary_interactionId_key" ON "ConversationSummary"("interactionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Quote_quoteNumber_key" ON "Quote"("quoteNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Order_orderNumber_key" ON "Order"("orderNumber");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Order_quoteId_key" ON "Order"("quoteId");

--- a/services/project-api/prisma/schema.prisma
+++ b/services/project-api/prisma/schema.prisma
@@ -8,15 +8,15 @@ datasource db {
 }
 
 model Project {
-  id          String         @id @default(cuid())
-  code        String         @unique
+  id          String    @id @default(cuid())
+  code        String    @unique
   name        String
   description String?
-  status      String         @default("draft")
+  status      String    @default("draft")
   startDate   DateTime
   endDate     DateTime?
-  createdAt   DateTime       @default(now())
-  updatedAt   DateTime       @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 
   plannedValue Float @default(0)
   earnedValue  Float @default(0)
@@ -30,10 +30,10 @@ model Project {
 }
 
 model Phase {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   projectId String
   name      String
-  sortOrder Int      @default(0)
+  sortOrder Int       @default(0)
   startDate DateTime?
   endDate   DateTime?
 
@@ -42,7 +42,7 @@ model Phase {
 }
 
 model Task {
-  id          String     @id @default(cuid())
+  id          String   @id @default(cuid())
   projectId   String
   phaseId     String?
   name        String
@@ -50,15 +50,15 @@ model Task {
   status      String
   startDate   DateTime
   endDate     DateTime
-  effortHours Float      @default(0)
-  orderIndex  Int        @default(0)
+  effortHours Float    @default(0)
+  orderIndex  Int      @default(0)
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   phase   Phase?  @relation(fields: [phaseId], references: [id], onDelete: SetNull)
 }
 
 model Risk {
-  id          String @id @default(cuid())
+  id          String  @id @default(cuid())
   projectId   String
   probability Int
   impact      Int
@@ -69,39 +69,194 @@ model Risk {
 }
 
 model ChatThread {
-  id               String        @id @default(cuid())
+  id               String   @id @default(cuid())
   projectId        String
   provider         String
-  externalThreadId String        @unique
+  externalThreadId String   @unique
   channelName      String?
   summary          String?
   summaryEmbedding String?
   summaryLanguage  String?
   summaryUsage     String?
-  createdAt        DateTime      @default(now())
-  updatedAt        DateTime      @updatedAt
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
   project  Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
   messages ChatMessage[]
 }
 
 model ChatMessage {
-  id        String   @id @default(cuid())
-  threadId  String
-  author    String
-  content   String
-  postedAt  DateTime
+  id       String   @id @default(cuid())
+  threadId String
+  author   String
+  content  String
+  postedAt DateTime
 
   thread ChatThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
 }
 
 model BurndownPoint {
-  id         String  @id @default(cuid())
+  id         String @id @default(cuid())
   projectId  String
   label      String
   planned    Float
   actual     Float
-  orderIndex Int     @default(0)
+  orderIndex Int    @default(0)
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+}
+
+model Customer {
+  id          String   @id @default(cuid())
+  externalId  String?  @unique
+  name        String
+  type        String   @default("CUSTOMER")
+  industry    String?
+  ownerUserId String?
+  tagsJson    String   @default("[]")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  contacts         Contact[]
+  opportunities    Opportunity[]
+  interactionNotes InteractionNote[]
+  quotes           Quote[]
+  orders           Order[]
+}
+
+model Contact {
+  id           String   @id @default(cuid())
+  customerId   String
+  name         String
+  role         String?
+  email        String?
+  phone        String?
+  slackUserId  String?
+  meetIdentity String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  customer Customer          @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  notes    InteractionNote[] @relation("ContactNotes")
+}
+
+model Opportunity {
+  id             String    @id @default(cuid())
+  customerId     String
+  title          String
+  stage          String    @default("LEAD")
+  amount         Float     @default(0)
+  currency       String    @default("JPY")
+  expectedClose  DateTime?
+  ownerUserId    String?
+  stageEnteredAt DateTime? @default(now())
+  probability    Int?      @default(0)
+  statusReason   String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  customer Customer          @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  notes    InteractionNote[] @relation("OpportunityNotes")
+}
+
+model InteractionNote {
+  id            String   @id @default(cuid())
+  customerId    String
+  contactId     String?
+  opportunityId String?
+  occurredAt    DateTime @default(now())
+  channel       String
+  rawText       String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  customer    Customer             @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  contact     Contact?             @relation("ContactNotes", fields: [contactId], references: [id], onDelete: SetNull)
+  opportunity Opportunity?         @relation("OpportunityNotes", fields: [opportunityId], references: [id], onDelete: SetNull)
+  summary     ConversationSummary?
+}
+
+model ConversationSummary {
+  id                    String   @id @default(cuid())
+  interactionId         String   @unique
+  summaryText           String
+  followupSuggestedJson String   @default("[]")
+  embedding             Bytes?
+  confidence            Float    @default(0)
+  createdAt             DateTime @default(now())
+
+  interaction InteractionNote @relation(fields: [interactionId], references: [id], onDelete: Cascade)
+}
+
+model Quote {
+  id          String    @id @default(cuid())
+  quoteNumber String    @unique
+  customerId  String
+  status      String    @default("DRAFT")
+  currency    String    @default("JPY")
+  totalAmount Float     @default(0)
+  validUntil  DateTime?
+  version     Int       @default(1)
+  submittedAt DateTime?
+  approvedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  customer Customer    @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  items    QuoteItem[]
+  order    Order?
+}
+
+model QuoteItem {
+  id           String  @id @default(cuid())
+  quoteId      String
+  productCode  String
+  description  String?
+  quantity     Int
+  unitPrice    Float   @default(0)
+  discountRate Float   @default(0)
+
+  quote Quote @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+}
+
+model Order {
+  id          String    @id @default(cuid())
+  orderNumber String    @unique
+  quoteId     String    @unique
+  customerId  String
+  status      String    @default("PENDING")
+  signedAt    DateTime?
+  paymentTerm String
+  totalAmount Float     @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  quote         Quote           @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+  customer      Customer        @relation(fields: [customerId], references: [id], onDelete: Cascade)
+  creditReviews CreditReview[]
+  auditLogs     OrderAuditLog[]
+}
+
+model CreditReview {
+  id             String    @id @default(cuid())
+  orderId        String
+  status         String    @default("REQUESTED")
+  reviewerUserId String?
+  score          Float?
+  remarks        String?
+  requestedAt    DateTime  @default(now())
+  decidedAt      DateTime?
+
+  order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
+}
+
+model OrderAuditLog {
+  id         String   @id @default(cuid())
+  orderId    String
+  changeType String
+  payload    String
+  createdAt  DateTime @default(now())
+  checksum   String
+
+  order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
 }

--- a/services/project-api/prisma/seed.ts
+++ b/services/project-api/prisma/seed.ts
@@ -3,6 +3,16 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function seed() {
+  await prisma.orderAuditLog.deleteMany();
+  await prisma.creditReview.deleteMany();
+  await prisma.order.deleteMany();
+  await prisma.quoteItem.deleteMany();
+  await prisma.quote.deleteMany();
+  await prisma.conversationSummary.deleteMany();
+  await prisma.interactionNote.deleteMany();
+  await prisma.opportunity.deleteMany();
+  await prisma.contact.deleteMany();
+  await prisma.customer.deleteMany();
   await prisma.chatMessage.deleteMany();
   await prisma.chatThread.deleteMany();
   await prisma.risk.deleteMany();
@@ -312,6 +322,142 @@ async function seed() {
       data: project,
     });
   }
+
+  const acme = await prisma.customer.create({
+    data: {
+      name: 'Acme Manufacturing',
+      type: 'CUSTOMER',
+      industry: 'Manufacturing',
+      tagsJson: JSON.stringify(['strategic', 'phase2']),
+      contacts: {
+        create: [
+          {
+            name: 'Hiro Tanaka',
+            role: 'Procurement Lead',
+            email: 'hiro.tanaka@acme.example',
+            phone: '+81-3-1234-5678',
+          },
+          {
+            name: 'Mina Sato',
+            role: 'IT Director',
+            email: 'mina.sato@acme.example',
+          },
+        ],
+      },
+    },
+    include: { contacts: true },
+  });
+
+  const acmeOpportunity = await prisma.opportunity.create({
+    data: {
+      customerId: acme.id,
+      title: 'ERP Phase2 Rollout',
+      stage: 'NEGOTIATION',
+      amount: 18_000_000,
+      currency: 'JPY',
+      probability: 65,
+      ownerUserId: 'user-sales-lead',
+      expectedClose: new Date('2025-11-30'),
+    },
+  });
+
+  const acmeNote = await prisma.interactionNote.create({
+    data: {
+      customerId: acme.id,
+      contactId: acme.contacts[0].id,
+      opportunityId: acmeOpportunity.id,
+      channel: 'Teams',
+      rawText: 'Reviewed pricing model; requested AI-assisted onboarding demo.',
+    },
+  });
+
+  await prisma.conversationSummary.create({
+    data: {
+      interactionId: acmeNote.id,
+      summaryText: 'Client wants assurance on AI onboarding; follow-up demo scheduled.',
+      followupSuggestedJson: JSON.stringify(['Prepare onboarding demo deck', 'Share AI ops runbook preview']),
+      confidence: 0.82,
+    },
+  });
+
+  const acmeQuote = await prisma.quote.create({
+    data: {
+      quoteNumber: 'Q-2025-0001',
+      customerId: acme.id,
+      status: 'PENDING_APPROVAL',
+      totalAmount: 18_500_000,
+      currency: 'JPY',
+      items: {
+        create: [
+          {
+            productCode: 'ERP-CORE',
+            description: 'ERP core license + support',
+            quantity: 1,
+            unitPrice: 12_000_000,
+          },
+          {
+            productCode: 'AI-ADDON',
+            description: 'AI Ops add-on bundle',
+            quantity: 1,
+            unitPrice: 6_500_000,
+            discountRate: 0.1,
+          },
+        ],
+      },
+    },
+  });
+
+  const acmeOrder = await prisma.order.create({
+    data: {
+      orderNumber: 'SO-2025-0001',
+      quoteId: acmeQuote.id,
+      customerId: acme.id,
+      status: 'PENDING',
+      paymentTerm: 'Net 30',
+      totalAmount: 18_500_000,
+    },
+  });
+
+  await prisma.creditReview.create({
+    data: {
+      orderId: acmeOrder.id,
+      status: 'APPROVED',
+      reviewerUserId: 'user-finance',
+      score: 82,
+      remarks: 'Credit limit sufficient. Proceed once PO is received.',
+      decidedAt: new Date('2025-10-10T02:30:00Z'),
+    },
+  });
+
+  await prisma.orderAuditLog.create({
+    data: {
+      orderId: acmeOrder.id,
+      changeType: 'status.change',
+      payload: JSON.stringify({ from: 'REQUESTED', to: 'APPROVED', reviewer: 'user-finance' }),
+      checksum: 'approved-2025-10-10',
+    },
+  });
+
+  const betaCustomer = await prisma.customer.create({
+    data: {
+      name: 'Beta Retail Holdings',
+      type: 'PROSPECT',
+      industry: 'Retail',
+      tagsJson: JSON.stringify(['pilot', 'high-touch']),
+    },
+  });
+
+  await prisma.opportunity.create({
+    data: {
+      customerId: betaCustomer.id,
+      title: 'Retail Expansion CRM',
+      stage: 'QUALIFIED',
+      amount: 9_800_000,
+      currency: 'JPY',
+      probability: 45,
+      ownerUserId: 'user-crm-specialist',
+    },
+  });
 }
 
 seed()

--- a/services/project-api/src/crm/controller.ts
+++ b/services/project-api/src/crm/controller.ts
@@ -1,0 +1,52 @@
+import { Body, Controller, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { CrmService } from './service';
+import {
+  AddInteractionNoteInput,
+  CreateCustomerInput,
+  CreateOpportunityInput,
+  UpdateCustomerInput,
+} from './dto/crm.input';
+import { CustomerModel, InteractionNoteModel, OpportunityModel } from './models/crm.model';
+
+@Controller('api/v1/crm')
+export class CrmController {
+  constructor(private readonly crmService: CrmService) {}
+
+  @Get('customers')
+  listCustomers(
+    @Query('search') search?: string,
+    @Query('type') type?: string,
+    @Query('industry') industry?: string,
+  ): Promise<CustomerModel[]> {
+    const filter = search || type || industry ? { search, type, industry } : undefined;
+    return this.crmService.listCustomers(filter);
+  }
+
+  @Post('customers')
+  createCustomer(@Body() input: CreateCustomerInput): Promise<CustomerModel> {
+    return this.crmService.createCustomer(input);
+  }
+
+  @Patch('customers/:id')
+  updateCustomer(
+    @Param('id') id: string,
+    @Body() input: UpdateCustomerInput,
+  ): Promise<CustomerModel> {
+    return this.crmService.updateCustomer(id, input);
+  }
+
+  @Get('customers/:id/opportunities')
+  customerOpportunities(@Param('id') id: string): Promise<OpportunityModel[]> {
+    return this.crmService.listOpportunities(id);
+  }
+
+  @Post('opportunities')
+  createOpportunity(@Body() input: CreateOpportunityInput): Promise<OpportunityModel> {
+    return this.crmService.createOpportunity(input);
+  }
+
+  @Post('interaction-notes')
+  addInteractionNote(@Body() input: AddInteractionNoteInput): Promise<InteractionNoteModel> {
+    return this.crmService.addInteractionNote(input);
+  }
+}

--- a/services/project-api/src/crm/dto/crm.input.ts
+++ b/services/project-api/src/crm/dto/crm.input.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { Field, Float, ID, InputType } from '@nestjs/graphql';
+import { GraphQLISODateTime } from 'graphql-scalars';
+
+@InputType()
+export class CustomerFilterInput {
+  @Field(() => String, { nullable: true })
+  search?: string;
+
+  @Field(() => String, { nullable: true })
+  type?: string;
+
+  @Field(() => String, { nullable: true })
+  industry?: string;
+}
+
+@InputType()
+export class CreateCustomerInput {
+  @Field(() => String)
+  name!: string;
+
+  @Field(() => String, { nullable: true })
+  type?: string;
+
+  @Field(() => String, { nullable: true })
+  industry?: string;
+
+  @Field(() => String, { nullable: true })
+  ownerUserId?: string;
+
+  @Field(() => [String], { nullable: true })
+  tags?: string[];
+}
+
+@InputType()
+export class UpdateCustomerInput {
+  @Field(() => String, { nullable: true })
+  name?: string;
+
+  @Field(() => String, { nullable: true })
+  type?: string;
+
+  @Field(() => String, { nullable: true })
+  industry?: string;
+
+  @Field(() => String, { nullable: true })
+  ownerUserId?: string;
+
+  @Field(() => [String], { nullable: true })
+  tags?: string[];
+}
+
+@InputType()
+export class CreateOpportunityInput {
+  @Field(() => ID)
+  customerId!: string;
+
+  @Field(() => String)
+  title!: string;
+
+  @Field(() => String, { nullable: true })
+  stage?: string;
+
+  @Field(() => Float, { nullable: true })
+  amount?: number;
+
+  @Field(() => String, { nullable: true })
+  currency?: string;
+
+  @Field(() => Int, { nullable: true })
+  probability?: number;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  expectedClose?: Date;
+}
+
+@InputType()
+export class AddInteractionNoteInput {
+  @Field(() => ID)
+  customerId!: string;
+
+  @Field(() => ID, { nullable: true })
+  contactId?: string;
+
+  @Field(() => ID, { nullable: true })
+  opportunityId?: string;
+
+  @Field(() => String)
+  channel!: string;
+
+  @Field(() => String)
+  rawText!: string;
+
+  @Field(() => String, { nullable: true })
+  summaryText?: string;
+
+  @Field(() => [String], { nullable: true })
+  followups?: string[];
+
+  @Field(() => Float, { nullable: true })
+  confidence?: number;
+}

--- a/services/project-api/src/crm/models/crm.model.ts
+++ b/services/project-api/src/crm/models/crm.model.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { Field, Float, ID, ObjectType } from '@nestjs/graphql';
+import { GraphQLISODateTime } from 'graphql-scalars';
+
+@ObjectType()
+export class ConversationSummaryModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field(() => String)
+  summaryText!: string;
+
+  @Field(() => [String])
+  followupSuggested!: string[];
+
+  @Field(() => Float)
+  confidence!: number;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt!: Date;
+}
+
+@ObjectType()
+export class InteractionNoteModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field(() => String)
+  channel!: string;
+
+  @Field(() => String)
+  rawText!: string;
+
+  @Field(() => GraphQLISODateTime)
+  occurredAt!: Date;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt!: Date;
+
+  @Field(() => ConversationSummaryModel, { nullable: true })
+  summary?: ConversationSummaryModel;
+}
+
+@ObjectType()
+export class ContactModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field(() => String)
+  name!: string;
+
+  @Field(() => String, { nullable: true })
+  role?: string;
+
+  @Field(() => String, { nullable: true })
+  email?: string;
+
+  @Field(() => String, { nullable: true })
+  phone?: string;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt!: Date;
+}
+
+@ObjectType()
+export class OpportunityModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field(() => String)
+  title!: string;
+
+  @Field(() => String)
+  stage!: string;
+
+  @Field(() => Float)
+  amount!: number;
+
+  @Field(() => String)
+  currency!: string;
+
+  @Field(() => Int, { nullable: true })
+  probability?: number;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  expectedClose?: Date;
+
+  @Field(() => [InteractionNoteModel])
+  notes!: InteractionNoteModel[];
+}
+
+@ObjectType()
+export class CustomerModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field(() => String)
+  name!: string;
+
+  @Field(() => String)
+  type!: string;
+
+  @Field(() => String, { nullable: true })
+  industry?: string;
+
+  @Field(() => String, { nullable: true })
+  ownerUserId?: string;
+
+  @Field(() => [String])
+  tags!: string[];
+
+  @Field(() => GraphQLISODateTime)
+  createdAt!: Date;
+
+  @Field(() => GraphQLISODateTime)
+  updatedAt!: Date;
+
+  @Field(() => [ContactModel])
+  contacts!: ContactModel[];
+
+  @Field(() => [OpportunityModel])
+  opportunities!: OpportunityModel[];
+}

--- a/services/project-api/src/crm/module.ts
+++ b/services/project-api/src/crm/module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
-import { CrmService } from './service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { CrmController } from './controller';
 import { CrmResolver } from './resolver';
+import { CrmService } from './service';
 
 @Module({
+  imports: [PrismaModule],
   providers: [CrmService, CrmResolver],
+  controllers: [CrmController],
 })
 export class CrmModule {}

--- a/services/project-api/src/crm/resolver.ts
+++ b/services/project-api/src/crm/resolver.ts
@@ -1,9 +1,60 @@
-import { Query, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { CrmService } from './service';
+import {
+  AddInteractionNoteInput,
+  CreateCustomerInput,
+  CreateOpportunityInput,
+  CustomerFilterInput,
+  UpdateCustomerInput,
+} from './dto/crm.input';
+import {
+  CustomerModel,
+  InteractionNoteModel,
+  OpportunityModel,
+} from './models/crm.model';
 
-@Resolver()
+@Resolver(() => CustomerModel)
 export class CrmResolver {
-  @Query(() => [String])
-  sampleCrm() {
-    return [];
+  constructor(private readonly crmService: CrmService) {}
+
+  @Query(() => [CustomerModel])
+  customers(@Args('filter', { nullable: true }) filter?: CustomerFilterInput): Promise<CustomerModel[]> {
+    const resolvedFilter = filter
+      ? { search: filter.search ?? undefined, type: filter.type ?? undefined, industry: filter.industry ?? undefined }
+      : undefined;
+    return this.crmService.listCustomers(resolvedFilter);
+  }
+
+  @Query(() => CustomerModel)
+  customer(@Args('id') id: string): Promise<CustomerModel> {
+    return this.crmService.getCustomer(id);
+  }
+
+  @Mutation(() => CustomerModel)
+  createCustomer(@Args('input') input: CreateCustomerInput): Promise<CustomerModel> {
+    return this.crmService.createCustomer(input);
+  }
+
+  @Mutation(() => CustomerModel)
+  updateCustomer(
+    @Args('id') id: string,
+    @Args('input') input: UpdateCustomerInput,
+  ): Promise<CustomerModel> {
+    return this.crmService.updateCustomer(id, input);
+  }
+
+  @Mutation(() => OpportunityModel)
+  createOpportunity(@Args('input') input: CreateOpportunityInput): Promise<OpportunityModel> {
+    return this.crmService.createOpportunity(input);
+  }
+
+  @Query(() => [OpportunityModel])
+  customerOpportunities(@Args('customerId') customerId: string): Promise<OpportunityModel[]> {
+    return this.crmService.listOpportunities(customerId);
+  }
+
+  @Mutation(() => InteractionNoteModel)
+  addInteractionNote(@Args('input') input: AddInteractionNoteInput): Promise<InteractionNoteModel> {
+    return this.crmService.addInteractionNote(input);
   }
 }

--- a/services/project-api/src/crm/service.ts
+++ b/services/project-api/src/crm/service.ts
@@ -1,8 +1,347 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  AddInteractionNoteInput,
+  CreateCustomerInput,
+  CreateOpportunityInput,
+  UpdateCustomerInput,
+} from './dto/crm.input';
+import {
+  ContactModel,
+  ConversationSummaryModel,
+  CustomerModel,
+  InteractionNoteModel,
+  OpportunityModel,
+} from './models/crm.model';
+
+type CustomerFilter = {
+  search?: string;
+  type?: string;
+  industry?: string;
+};
+
+interface ConversationSummaryEntity {
+  id: string;
+  summaryText: string;
+  followupSuggestedJson: string;
+  confidence: number | null;
+  createdAt: Date;
+}
+
+interface InteractionNoteEntity {
+  id: string;
+  channel: string;
+  rawText: string;
+  occurredAt: Date;
+  createdAt: Date;
+  summary: ConversationSummaryEntity | null;
+}
+
+interface ContactEntity {
+  id: string;
+  name: string;
+  role: string | null;
+  email: string | null;
+  phone: string | null;
+  createdAt: Date;
+}
+
+interface OpportunityEntity {
+  id: string;
+  customerId: string;
+  title: string;
+  stage: string;
+  amount: number | null;
+  currency: string;
+  probability: number | null;
+  expectedClose: Date | null;
+  notes: InteractionNoteEntity[];
+}
+
+interface CustomerEntity {
+  id: string;
+  name: string;
+  type: string;
+  industry: string | null;
+  ownerUserId: string | null;
+  tagsJson: string;
+  createdAt: Date;
+  updatedAt: Date;
+  contacts: ContactEntity[];
+  opportunities: OpportunityEntity[];
+}
 
 @Injectable()
 export class CrmService {
-  findAll() {
-    return [];
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listCustomers(filter?: CustomerFilter): Promise<CustomerModel[]> {
+    const where: Prisma.CustomerWhereInput = {};
+
+    const filterValues: CustomerFilter = filter ? { ...filter } : {};
+
+    if (filterValues.type) {
+      where.type = filterValues.type;
+    }
+
+    if (filterValues.industry) {
+      where.industry = { equals: filterValues.industry, mode: 'insensitive' };
+    }
+
+    if (filterValues.search) {
+      where.OR = [
+        { name: { contains: filterValues.search, mode: 'insensitive' } },
+        { industry: { contains: filterValues.search, mode: 'insensitive' } },
+      ];
+    }
+
+    const customers = await this.prisma.customer.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      include: {
+        contacts: true,
+        opportunities: {
+          orderBy: { createdAt: 'desc' },
+          include: {
+            notes: {
+              orderBy: { createdAt: 'desc' },
+              include: { summary: true },
+            },
+          },
+        },
+      },
+    });
+
+    return (customers as CustomerEntity[]).map((entity) => this.mapCustomer(entity));
+  }
+
+  async getCustomer(id: string): Promise<CustomerModel> {
+    const customer = await this.prisma.customer.findUnique({
+      where: { id },
+      include: {
+        contacts: true,
+        opportunities: {
+          orderBy: { createdAt: 'desc' },
+          include: {
+            notes: {
+              orderBy: { createdAt: 'desc' },
+              include: { summary: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!customer) {
+      throw new NotFoundException(`Customer ${id} not found`);
+    }
+
+    return this.mapCustomer(customer as CustomerEntity);
+  }
+
+  async createCustomer(input: CreateCustomerInput): Promise<CustomerModel> {
+    const customer = await this.prisma.customer.create({
+      data: {
+        name: input.name,
+        type: input.type ?? 'CUSTOMER',
+        industry: input.industry,
+        ownerUserId: input.ownerUserId,
+        tagsJson: JSON.stringify(input.tags ?? []),
+      },
+      include: {
+        contacts: true,
+        opportunities: {
+          include: { notes: { include: { summary: true } } },
+        },
+      },
+    });
+
+    return this.mapCustomer(customer);
+  }
+
+  async updateCustomer(id: string, input: UpdateCustomerInput): Promise<CustomerModel> {
+    const customer = await this.prisma.customer.update({
+      where: { id },
+      data: {
+        name: input.name ?? undefined,
+        type: input.type ?? undefined,
+        industry: input.industry ?? undefined,
+        ownerUserId: input.ownerUserId ?? undefined,
+        tagsJson: input.tags ? JSON.stringify(input.tags) : undefined,
+      },
+      include: {
+        contacts: true,
+        opportunities: {
+          include: { notes: { include: { summary: true } } },
+        },
+      },
+    });
+
+    return this.mapCustomer(customer);
+  }
+
+  async createOpportunity(input: CreateOpportunityInput): Promise<OpportunityModel> {
+    await this.assertCustomerExists(input.customerId);
+
+    const opportunity = await this.prisma.opportunity.create({
+      data: {
+        customerId: input.customerId,
+        title: input.title,
+        stage: input.stage ?? 'LEAD',
+        amount: input.amount ?? 0,
+        currency: input.currency ?? 'JPY',
+        probability: input.probability ?? null,
+        expectedClose: input.expectedClose ?? null,
+      },
+      include: {
+        notes: {
+          orderBy: { createdAt: 'desc' },
+          include: { summary: true },
+        },
+      },
+    });
+
+    return this.mapOpportunity(opportunity as OpportunityEntity);
+  }
+
+  async addInteractionNote(input: AddInteractionNoteInput): Promise<InteractionNoteModel> {
+    await this.assertCustomerExists(input.customerId);
+
+    const note = await this.prisma.interactionNote.create({
+      data: {
+        customerId: input.customerId,
+        contactId: input.contactId ?? null,
+        opportunityId: input.opportunityId ?? null,
+        channel: input.channel,
+        rawText: input.rawText,
+      },
+    });
+
+    if (input.summaryText || (input.followups && input.followups.length)) {
+      await this.prisma.conversationSummary.create({
+        data: {
+          interactionId: note.id,
+          summaryText: input.summaryText ?? '',
+          followupSuggestedJson: JSON.stringify(input.followups ?? []),
+          confidence: input.confidence ?? 0,
+        },
+      });
+    }
+
+    return this.getInteractionNote(note.id);
+  }
+
+  async listOpportunities(customerId: string): Promise<OpportunityModel[]> {
+    const opportunities = await this.prisma.opportunity.findMany({
+      where: { customerId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        notes: {
+          orderBy: { createdAt: 'desc' },
+          include: { summary: true },
+        },
+      },
+    });
+
+    return (opportunities as OpportunityEntity[]).map((op) => this.mapOpportunity(op));
+  }
+
+  private async getInteractionNote(id: string): Promise<InteractionNoteModel> {
+    const note = await this.prisma.interactionNote.findUnique({
+      where: { id },
+      include: {
+        summary: true,
+      },
+    });
+
+    if (!note) {
+      throw new NotFoundException(`Interaction note ${id} not found`);
+    }
+
+    return this.mapInteractionNote(note as InteractionNoteEntity);
+  }
+
+  private async assertCustomerExists(id: string): Promise<void> {
+    const exists = await this.prisma.customer.count({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException(`Customer ${id} not found`);
+    }
+  }
+
+  private mapCustomer(entity: CustomerEntity): CustomerModel {
+    return {
+      id: entity.id,
+      name: entity.name,
+      type: entity.type,
+      industry: entity.industry ?? undefined,
+      ownerUserId: entity.ownerUserId ?? undefined,
+      tags: this.safeParseStringArray(entity.tagsJson),
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      contacts: entity.contacts.map((contact) => this.mapContact(contact)),
+      opportunities: entity.opportunities.map((opportunity) => this.mapOpportunity(opportunity)),
+    };
+  }
+
+  private mapContact(entity: ContactEntity): ContactModel {
+    return {
+      id: entity.id,
+      name: entity.name,
+      role: entity.role ?? undefined,
+      email: entity.email ?? undefined,
+      phone: entity.phone ?? undefined,
+      createdAt: entity.createdAt,
+    };
+  }
+
+  private mapOpportunity(entity: OpportunityEntity): OpportunityModel {
+    return {
+      id: entity.id,
+      title: entity.title,
+      stage: entity.stage,
+      amount: entity.amount ?? 0,
+      currency: entity.currency,
+      probability: entity.probability ?? undefined,
+      expectedClose: entity.expectedClose ?? undefined,
+      notes: entity.notes.map((note) => this.mapInteractionNote(note)),
+    };
+  }
+
+  private mapInteractionNote(entity: InteractionNoteEntity): InteractionNoteModel {
+    return {
+      id: entity.id,
+      channel: entity.channel,
+      rawText: entity.rawText,
+      occurredAt: entity.occurredAt,
+      createdAt: entity.createdAt,
+      summary: entity.summary ? this.mapSummary(entity.summary) : undefined,
+    };
+  }
+
+  private mapSummary(entity: ConversationSummaryEntity): ConversationSummaryModel {
+    return {
+      id: entity.id,
+      summaryText: entity.summaryText,
+      followupSuggested: this.safeParseStringArray(entity.followupSuggestedJson),
+      confidence: entity.confidence ?? 0,
+      createdAt: entity.createdAt,
+    };
+  }
+
+  private safeParseStringArray(value: string | null | undefined): string[] {
+    if (!value) {
+      return [];
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item));
+      }
+      return [];
+    } catch {
+      return [];
+    }
   }
 }

--- a/services/project-api/src/sales/controller.ts
+++ b/services/project-api/src/sales/controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { SalesService } from './service';
+import { ApproveCreditReviewInput } from './dto/credit-review.dto';
+import { CreateOrderInput, OrderModel } from './dto/order.dto';
+import { CreateQuoteInput, QuoteFilterInput, QuoteModel } from './dto/quote.dto';
+import { CreditReviewModel } from './dto/credit-review.dto';
+
+@Controller('api/v1/sales')
+export class SalesController {
+  constructor(private readonly salesService: SalesService) {}
+
+  @Get('quotes')
+  listQuotes(
+    @Query() filter?: QuoteFilterInput,
+  ): Promise<QuoteModel[]> {
+    return this.salesService.listQuotes(filter);
+  }
+
+  @Post('quotes')
+  createQuote(@Body() input: CreateQuoteInput): Promise<QuoteModel> {
+    return this.salesService.createQuote(input);
+  }
+
+  @Get('orders')
+  listOrders(@Query('customerId') customerId?: string): Promise<OrderModel[]> {
+    return this.salesService.listOrders(customerId);
+  }
+
+  @Post('orders')
+  createOrder(@Body() input: CreateOrderInput): Promise<OrderModel> {
+    return this.salesService.createOrder(input);
+  }
+
+  @Post('orders/:orderId/credit-review')
+  approveCreditReview(
+    @Param('orderId') orderId: string,
+    @Body() body: ApproveCreditReviewInput,
+  ): Promise<CreditReviewModel> {
+    return this.salesService.approveCreditReview({ ...body, orderId });
+  }
+}

--- a/services/project-api/src/sales/dto/credit-review.dto.ts
+++ b/services/project-api/src/sales/dto/credit-review.dto.ts
@@ -1,4 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
+import { GraphQLISODateTime } from 'graphql-scalars';
 
 @ObjectType()
 export class CreditReviewModel {
@@ -16,6 +18,12 @@ export class CreditReviewModel {
 
   @Field({ nullable: true })
   remarks?: string;
+
+  @Field(() => GraphQLISODateTime)
+  requestedAt!: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  decidedAt?: Date;
 }
 
 @InputType()

--- a/services/project-api/src/sales/dto/order.dto.ts
+++ b/services/project-api/src/sales/dto/order.dto.ts
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
+import { GraphQLISODateTime } from 'graphql-scalars';
+import { CreditReviewModel } from './credit-review.dto';
 
 @ObjectType()
 export class OrderModel {
@@ -11,14 +14,29 @@ export class OrderModel {
   @Field(() => String)
   quoteId!: string;
 
+  @Field(() => String)
+  customerId!: string;
+
   @Field()
   status!: string;
 
   @Field(() => Float)
   totalAmount!: number;
 
-  @Field({ nullable: true })
+  @Field()
+  paymentTerm!: string;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
   signedAt?: Date;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt!: Date;
+
+  @Field(() => GraphQLISODateTime)
+  updatedAt!: Date;
+
+  @Field(() => [CreditReviewModel])
+  creditReviews!: CreditReviewModel[];
 }
 
 @InputType()
@@ -26,9 +44,14 @@ export class CreateOrderInput {
   @Field(() => ID)
   quoteId!: string;
 
+  @Field(() => String, { nullable: true })
+  orderNumber?: string;
+
   @Field(() => String)
   paymentTerm!: string;
 
-  @Field(() => Float)
-  totalAmount!: number;
+  @Field(() => Float, { nullable: true })
+  totalAmount?: number;
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  signedAt?: Date;
 }

--- a/services/project-api/src/sales/dto/quote.dto.ts
+++ b/services/project-api/src/sales/dto/quote.dto.ts
@@ -1,4 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, Int, ObjectType } from '@nestjs/graphql';
+import { GraphQLISODateTime } from 'graphql-scalars';
+import { OrderModel } from './order.dto';
+import { CreditReviewModel } from './credit-review.dto';
 
 @ObjectType()
 export class QuoteItemModel {
@@ -7,6 +11,9 @@ export class QuoteItemModel {
 
   @Field(() => String)
   productCode!: string;
+
+  @Field(() => String, { nullable: true })
+  description?: string;
 
   @Field(() => Int)
   quantity!: number;
@@ -35,14 +42,41 @@ export class QuoteModel {
   @Field(() => Float)
   totalAmount!: number;
 
+  @Field(() => String)
+  currency!: string;
+
+  @Field(() => Int)
+  version!: number;
+
+  @Field(() => GraphQLISODateTime)
+  createdAt!: Date;
+
+  @Field(() => GraphQLISODateTime)
+  updatedAt!: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  submittedAt?: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  approvedAt?: Date;
+
   @Field(() => [QuoteItemModel])
   items!: QuoteItemModel[];
+
+  @Field(() => OrderModel, { nullable: true })
+  order?: OrderModel;
+
+  @Field(() => [CreditReviewModel])
+  creditReviews!: CreditReviewModel[];
 }
 
 @InputType()
 export class QuoteItemInput {
   @Field(() => String)
   productCode!: string;
+
+  @Field(() => String, { nullable: true })
+  description?: string;
 
   @Field(() => Int)
   quantity!: number;
@@ -64,13 +98,16 @@ export class CreateQuoteInput {
 
   @Field(() => String, { nullable: true })
   currency?: string;
+
+  @Field(() => String, { nullable: true })
+  quoteNumber?: string;
 }
 
 @InputType()
-export class SubmitQuoteInput {
-  @Field(() => ID)
-  quoteId!: string;
+export class QuoteFilterInput {
+  @Field(() => String, { nullable: true })
+  customerId?: string;
 
   @Field(() => String, { nullable: true })
-  approverId?: string;
+  status?: string;
 }

--- a/services/project-api/src/sales/module.ts
+++ b/services/project-api/src/sales/module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
-import { SalesService } from './service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { SalesController } from './controller';
 import { SalesResolver } from './resolver';
+import { SalesService } from './service';
 
 @Module({
+  imports: [PrismaModule],
   providers: [SalesService, SalesResolver],
+  controllers: [SalesController],
 })
 export class SalesModule {}

--- a/services/project-api/src/sales/resolver.ts
+++ b/services/project-api/src/sales/resolver.ts
@@ -1,6 +1,6 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { SalesService } from './service';
-import { QuoteModel, CreateQuoteInput } from './dto/quote.dto';
+import { QuoteModel, CreateQuoteInput, QuoteFilterInput } from './dto/quote.dto';
 import { OrderModel, CreateOrderInput } from './dto/order.dto';
 import { CreditReviewModel, ApproveCreditReviewInput } from './dto/credit-review.dto';
 
@@ -9,24 +9,29 @@ export class SalesResolver {
   constructor(private readonly service: SalesService) {}
 
   @Query(() => [QuoteModel])
-  quotes(): QuoteModel[] {
-    return this.service.listQuotes();
+  quotes(@Args('filter', { nullable: true }) filter?: QuoteFilterInput): Promise<QuoteModel[]> {
+    return this.service.listQuotes(filter);
+  }
+
+  @Query(() => [OrderModel])
+  orders(@Args('customerId', { nullable: true }) customerId?: string): Promise<OrderModel[]> {
+    return this.service.listOrders(customerId);
   }
 
   @Mutation(() => QuoteModel)
-  createQuote(@Args('input') input: CreateQuoteInput): QuoteModel {
+  createQuote(@Args('input') input: CreateQuoteInput): Promise<QuoteModel> {
     return this.service.createQuote(input);
   }
 
   @Mutation(() => OrderModel)
-  createOrder(@Args('input') input: CreateOrderInput): OrderModel {
+  createOrder(@Args('input') input: CreateOrderInput): Promise<OrderModel> {
     return this.service.createOrder(input);
   }
 
   @Mutation(() => CreditReviewModel)
   approveCreditReview(
     @Args('input') input: ApproveCreditReviewInput,
-  ): CreditReviewModel {
+  ): Promise<CreditReviewModel> {
     return this.service.approveCreditReview(input);
   }
 }

--- a/services/project-api/src/sales/service.ts
+++ b/services/project-api/src/sales/service.ts
@@ -1,48 +1,267 @@
-import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 import { ApproveCreditReviewInput, CreditReviewModel } from './dto/credit-review.dto';
 import { CreateOrderInput, OrderModel } from './dto/order.dto';
-import { CreateQuoteInput, QuoteModel } from './dto/quote.dto';
+import { CreateQuoteInput, QuoteFilterInput, QuoteModel } from './dto/quote.dto';
+
+interface QuoteItemEntity {
+  id: string;
+  productCode: string;
+  description: string | null;
+  quantity: number;
+  unitPrice: number;
+  discountRate: number;
+}
+
+interface CreditReviewEntity {
+  id: string;
+  orderId: string;
+  status: string;
+  score: number | null;
+  remarks: string | null;
+  requestedAt: Date;
+  decidedAt: Date | null;
+}
+
+interface OrderEntity {
+  id: string;
+  orderNumber: string;
+  quoteId: string;
+  customerId: string;
+  status: string;
+  totalAmount: number;
+  paymentTerm: string;
+  signedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  creditReviews: CreditReviewEntity[];
+}
+
+interface QuoteEntity {
+  id: string;
+  quoteNumber: string;
+  customerId: string;
+  status: string;
+  totalAmount: number;
+  currency: string;
+  version: number;
+  createdAt: Date;
+  updatedAt: Date;
+  submittedAt: Date | null;
+  approvedAt: Date | null;
+  items: QuoteItemEntity[];
+  order: OrderEntity | null;
+}
 
 @Injectable()
 export class SalesService {
-  listQuotes(): QuoteModel[] {
-    return [];
+  constructor(private readonly prisma: PrismaService) {}
+
+  private readonly quoteInclude = {
+    items: true,
+    order: {
+      include: {
+        creditReviews: {
+          orderBy: { requestedAt: 'desc' },
+        },
+      },
+    },
+  } satisfies Prisma.QuoteInclude;
+
+  private readonly orderInclude = {
+    creditReviews: {
+      orderBy: { requestedAt: 'desc' },
+    },
+  } satisfies Prisma.OrderInclude;
+
+  async listQuotes(filter?: QuoteFilterInput): Promise<QuoteModel[]> {
+    const where: Prisma.QuoteWhereInput = {};
+    if (filter?.customerId) {
+      where.customerId = filter.customerId;
+    }
+    if (filter?.status) {
+      where.status = filter.status;
+    }
+
+    const quotes = await this.prisma.quote.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      include: this.quoteInclude,
+    });
+
+    return (quotes as QuoteEntity[]).map((quote) => this.mapQuote(quote));
   }
 
-  createQuote(input: CreateQuoteInput): QuoteModel {
+  async createQuote(input: CreateQuoteInput): Promise<QuoteModel> {
+    const totalAmount = this.calculateTotalAmount(input.items);
+
+    const quote = await this.prisma.quote.create({
+      data: {
+        quoteNumber: input.quoteNumber ?? this.generateQuoteNumber(),
+        customerId: input.customerId,
+        status: 'DRAFT',
+        currency: input.currency ?? 'JPY',
+        totalAmount,
+        items: {
+          create: input.items.map((item) => ({
+            productCode: item.productCode,
+            description: item.description,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            discountRate: item.discountRate,
+          })),
+        },
+      },
+      include: this.quoteInclude,
+    });
+
+    return this.mapQuote(quote as QuoteEntity);
+  }
+
+  async createOrder(input: CreateOrderInput): Promise<OrderModel> {
+    const quote = await this.prisma.quote.findUnique({ where: { id: input.quoteId } });
+
+    if (!quote) {
+      throw new NotFoundException(`Quote ${input.quoteId} not found`);
+    }
+
+    const order = await this.prisma.order.create({
+      data: {
+        orderNumber: input.orderNumber ?? this.generateOrderNumber(),
+        quoteId: quote.id,
+        customerId: quote.customerId,
+        status: 'PENDING',
+        paymentTerm: input.paymentTerm,
+        signedAt: input.signedAt ?? null,
+        totalAmount: input.totalAmount ?? quote.totalAmount,
+      },
+      include: this.orderInclude,
+    });
+
+    await this.prisma.orderAuditLog.create({
+      data: {
+        orderId: order.id,
+        changeType: 'order.created',
+        payload: JSON.stringify({ orderNumber: order.orderNumber, totalAmount: order.totalAmount }),
+        checksum: `order-created-${order.id}`,
+      },
+    }).catch(() => undefined);
+
+    return this.mapOrder(order as OrderEntity);
+  }
+
+  async approveCreditReview(input: ApproveCreditReviewInput): Promise<CreditReviewModel> {
+    const order = await this.prisma.order.findUnique({ where: { id: input.orderId } });
+    if (!order) {
+      throw new NotFoundException(`Order ${input.orderId} not found`);
+    }
+
+    const review = await this.prisma.creditReview.create({
+      data: {
+        orderId: order.id,
+        status: 'APPROVED',
+        score: input.score,
+        remarks: input.remarks ?? null,
+        decidedAt: new Date(),
+      },
+    });
+
+    await this.prisma.order.update({
+      where: { id: order.id },
+      data: { status: 'FULFILLED' },
+    });
+
+    await this.prisma.orderAuditLog.create({
+      data: {
+        orderId: order.id,
+        changeType: 'credit-review',
+        payload: JSON.stringify({ score: input.score, remarks: input.remarks ?? null }),
+        checksum: `credit-review-${order.id}-${review.id}`,
+      },
+    }).catch(() => undefined);
+
+    return this.mapCreditReview(review as CreditReviewEntity);
+  }
+
+  async listOrders(customerId?: string): Promise<OrderModel[]> {
+    const orders = await this.prisma.order.findMany({
+      where: customerId ? { customerId } : undefined,
+      orderBy: { createdAt: 'desc' },
+      include: this.orderInclude,
+    });
+
+    return (orders as OrderEntity[]).map((order) => this.mapOrder(order));
+  }
+
+  private mapQuote(entity: QuoteEntity): QuoteModel {
     return {
-      id: 'new-quote',
-      quoteNumber: 'Q-0000',
-      customerId: input.customerId,
-      status: 'Draft',
-      totalAmount: input.items.reduce((acc, item) => acc + item.unitPrice * item.quantity, 0),
-      items: input.items.map((item, index) => ({
-        id: `item-${index}`,
+      id: entity.id,
+      quoteNumber: entity.quoteNumber,
+      customerId: entity.customerId,
+      status: entity.status,
+      totalAmount: entity.totalAmount,
+      currency: entity.currency,
+      version: entity.version,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      submittedAt: entity.submittedAt ?? undefined,
+      approvedAt: entity.approvedAt ?? undefined,
+      items: entity.items.map((item) => ({
+        id: item.id,
         productCode: item.productCode,
+        description: item.description ?? undefined,
         quantity: item.quantity,
         unitPrice: item.unitPrice,
         discountRate: item.discountRate,
       })),
+      order: entity.order ? this.mapOrder(entity.order) : undefined,
+      creditReviews: entity.order ? entity.order.creditReviews.map((review) => this.mapCreditReview(review)) : [],
     };
   }
 
-  createOrder(input: CreateOrderInput): OrderModel {
+  private mapOrder(entity: OrderEntity): OrderModel {
     return {
-      id: 'new-order',
-      orderNumber: 'O-0000',
-      quoteId: input.quoteId,
-      status: 'Pending',
-      totalAmount: input.totalAmount,
+      id: entity.id,
+      orderNumber: entity.orderNumber,
+      quoteId: entity.quoteId,
+      customerId: entity.customerId,
+      status: entity.status,
+      totalAmount: entity.totalAmount,
+      paymentTerm: entity.paymentTerm,
+      signedAt: entity.signedAt ?? undefined,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      creditReviews: entity.creditReviews.map((review) => this.mapCreditReview(review)),
     };
   }
 
-  approveCreditReview(input: ApproveCreditReviewInput): CreditReviewModel {
+  private mapCreditReview(entity: CreditReviewEntity): CreditReviewModel {
     return {
-      id: 'credit-review',
-      orderId: input.orderId,
-      status: 'Approved',
-      score: input.score,
-      remarks: input.remarks,
+      id: entity.id,
+      orderId: entity.orderId,
+      status: entity.status,
+      score: entity.score ?? undefined,
+      remarks: entity.remarks ?? undefined,
+      requestedAt: entity.requestedAt,
+      decidedAt: entity.decidedAt ?? undefined,
     };
+  }
+
+  private calculateTotalAmount(items: CreateQuoteInput['items']): number {
+    return items.reduce((total, item) => {
+      const discount = item.discountRate ?? 0;
+      const line = item.unitPrice * item.quantity * (1 - discount);
+      return total + line;
+    }, 0);
+  }
+
+  private generateQuoteNumber(): string {
+    return `Q-${new Date().getFullYear()}-${randomUUID().slice(0, 8).toUpperCase()}`;
+  }
+
+  private generateOrderNumber(): string {
+    return `SO-${new Date().getFullYear()}-${randomUUID().slice(0, 8).toUpperCase()}`;
   }
 }


### PR DESCRIPTION
## Summary
- add Prisma models/migrations for CRM customers/opportunities and Sales quote/order flows
- implement GraphQL + REST resolvers/controllers for CRM and Sales with Prisma-backed services
- seed sample data, add release runbook, and document new endpoints and workflows

## Testing
- npx prisma migrate dev --name phase3_crm_sales_init
- npx eslint src/crm src/sales