### PR TITLE
docs: finalize sales ops slack channels

### DIFF
--- a/docs/runbooks/crm-sales-release.md
+++ b/docs/runbooks/crm-sales-release.md
@@ -15,7 +15,7 @@ Phase3 本実装に合わせて CRM / Sales モジュールを本番適用する
 2. `DATABASE_URL` を本番環境の接続文字列に設定し、`npx prisma migrate deploy` を実行
 3. `scripts/ci/run-codex-template-smoke.sh` を実行し、新テンプレートのテンプレ生成が成功することを確認
 4. `api/v1/crm/customers` / `api/v1/sales/quotes` / `api/v1/sales/metrics` を `curl` で実行し、200 応答と想定データが返ることを確認
-5. Slack `#sales-ops` と PagerDuty `Sales Ops` エスカレーションポリシーへリリース開始を共有し、クレジット承認時の通知ルールを再確認
+5. Slack `#sales-ops`（リリース実況）と `#sales-ops-alerts`（CloudWatch アラート受信）および PagerDuty `Sales Ops` エスカレーションポリシーへリリース開始を共有し、クレジット承認時の通知ルールを再確認
 
 ## 3. ロールバック
 - [ ] リリース後 60 分以内の障害は `npx prisma migrate resolve --rolled-back` を利用して直近マイグレーションをロールバック

--- a/docs/specs/sales/requirements.md
+++ b/docs/specs/sales/requirements.md
@@ -61,4 +61,4 @@ REST エンドポイント（初期案）:
 ## 8. 未確定事項
 - 与信外部サービスの最終選定（AWS Marketplace vs 自社）
 - 電子帳簿法ログのバックアップ戦略（S3 Glacier Deep Archive）
-- Slack 通知チャネル（#sales-ops or #finance-alerts）
+- Slack 通知チャネル：CloudWatch アラートは `#sales-ops-alerts`、リリース実況・KPI 共有は `#sales-ops`


### PR DESCRIPTION
## Summary
- align sales runbook and requirements spec on dedicated Slack channels for metrics alerts vs release comms
- document  for CloudWatch alarms and keep  for KPI updates to close Issue #303 slack checklist

## Testing
- n/a (docs only)
