### PR TITLE
fix(e2e): align graphql datetime scalars and seed data

### DIFF
--- a/services/project-api/prisma/seed.ts
+++ b/services/project-api/prisma/seed.ts
@@ -236,11 +236,102 @@ async function seed() {
     },
   ];
 
+  const gammaProject = {
+    code: 'GAMMA-03',
+    name: 'Gamma Compliance Automation',
+    description: 'Automate compliance evidence collection across finance and HR.',
+    status: 'planning',
+    startDate: new Date('2025-05-01'),
+    endDate: new Date('2025-12-31'),
+    plannedValue: 75000,
+    earnedValue: 15000,
+    actualCost: 12000,
+    phases: {
+      create: [
+        {
+          id: 'phase-gamma-design',
+          name: 'Design',
+          sortOrder: 1,
+          startDate: new Date('2025-05-01'),
+          endDate: new Date('2025-06-15'),
+        },
+        {
+          id: 'phase-gamma-automation',
+          name: 'Automation Build',
+          sortOrder: 2,
+          startDate: new Date('2025-06-16'),
+          endDate: new Date('2025-10-31'),
+        },
+      ],
+    },
+    tasks: {
+      create: [
+        {
+          name: 'Compliance Requirement Mapping',
+          phaseId: 'phase-gamma-design',
+          status: 'inProgress',
+          startDate: new Date('2025-05-05'),
+          endDate: new Date('2025-05-25'),
+          effortHours: 120,
+          orderIndex: 1,
+        },
+        {
+          name: 'Evidence Collector Bot',
+          phaseId: 'phase-gamma-automation',
+          status: 'todo',
+          startDate: new Date('2025-07-01'),
+          endDate: new Date('2025-08-31'),
+          effortHours: 200,
+          orderIndex: 2,
+        },
+      ],
+    },
+    risks: {
+      create: [
+        { probability: 35, impact: 3, status: 'new', summary: 'Regulatory change mid-project' },
+      ],
+    },
+    burndown: {
+      create: [
+        { label: 'Sprint 1', planned: 80, actual: 78, orderIndex: 1 },
+        { label: 'Sprint 2', planned: 160, actual: 150, orderIndex: 2 },
+      ],
+    },
+    chatThreads: {
+      create: [
+        {
+          provider: 'Slack',
+          externalThreadId: 'gamma-thread-015',
+          channelName: 'gamma-compliance-weekly',
+          summary: 'Discussed evidence automation scope and dependency on HR data export.',
+          messages: {
+            create: [
+              {
+                author: 'ComplianceLead',
+                content: 'Need integration with HR data export before automation sprint.',
+                postedAt: new Date('2025-05-10T10:00:00Z'),
+              },
+              {
+                author: 'AutomationEngineer',
+                content: 'Prototype bot ready for demo next sprint.',
+                postedAt: new Date('2025-05-10T12:15:00Z'),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
   for (const project of projects) {
     await prisma.project.create({
       data: project,
     });
   }
+
+  await prisma.project.create({
+    data: gammaProject,
+  });
 
   const acme = await prisma.customer.create({
     data: {

--- a/services/project-api/src/crm/dto/customer.input.ts
+++ b/services/project-api/src/crm/dto/customer.input.ts
@@ -1,6 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, Int } from '@nestjs/graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+const ISODateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @InputType()
 export class CustomerFilterInput {
@@ -70,7 +72,7 @@ export class CreateOpportunityInput {
   @Field(() => Int, { nullable: true })
   probability?: number;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => ISODateTimeScalar, { nullable: true })
   expectedClose?: Date;
 }
 

--- a/services/project-api/src/crm/models/customer.model.ts
+++ b/services/project-api/src/crm/models/customer.model.ts
@@ -1,6 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, Int, ObjectType } from '@nestjs/graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+const DateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @ObjectType()
 export class ConversationSummaryModel {
@@ -16,7 +18,7 @@ export class ConversationSummaryModel {
   @Field(() => Float)
   confidence!: number;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   createdAt!: Date;
 }
 
@@ -31,10 +33,10 @@ export class InteractionNoteModel {
   @Field(() => String)
   rawText!: string;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   occurredAt!: Date;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   createdAt!: Date;
 
   @Field(() => ConversationSummaryModel, { nullable: true })
@@ -58,7 +60,7 @@ export class ContactModel {
   @Field(() => String, { nullable: true })
   phone?: string;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   createdAt!: Date;
 }
 
@@ -82,7 +84,7 @@ export class OpportunityModel {
   @Field(() => Int, { nullable: true })
   probability?: number;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => DateTimeScalar, { nullable: true })
   expectedClose?: Date;
 
   @Field(() => [InteractionNoteModel])
@@ -109,10 +111,10 @@ export class CustomerModel {
   @Field(() => [String])
   tags!: string[];
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   createdAt!: Date;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   updatedAt!: Date;
 
   @Field(() => [ContactModel])

--- a/services/project-api/src/hr/dto/review-cycle.dto.ts
+++ b/services/project-api/src/hr/dto/review-cycle.dto.ts
@@ -1,8 +1,8 @@
 import { Field, ID, InputType, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { GraphQLScalarType } from 'graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLDateTime } from 'graphql-scalars';
 
-const ISODateTimeScalar = GraphQLISODateTime as GraphQLScalarType<Date, string>;
+const ISODateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @ObjectType()
 export class ReviewCycleModel {

--- a/services/project-api/src/sales/dto/credit-review.dto.ts
+++ b/services/project-api/src/sales/dto/credit-review.dto.ts
@@ -1,6 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+const DateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @ObjectType()
 export class CreditReviewModel {
@@ -19,10 +21,10 @@ export class CreditReviewModel {
   @Field({ nullable: true })
   remarks?: string;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   requestedAt!: Date;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => DateTimeScalar, { nullable: true })
   decidedAt?: Date;
 }
 

--- a/services/project-api/src/sales/dto/order.dto.ts
+++ b/services/project-api/src/sales/dto/order.dto.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, ObjectType } from '@nestjs/graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { CreditReviewModel } from './credit-review.dto';
+
+const DateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @ObjectType()
 export class OrderModel {
@@ -26,13 +28,13 @@ export class OrderModel {
   @Field(() => String)
   paymentTerm!: string;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => DateTimeScalar, { nullable: true })
   signedAt?: Date;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   createdAt!: Date;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   updatedAt!: Date;
 
   @Field(() => [CreditReviewModel])
@@ -53,6 +55,6 @@ export class CreateOrderInput {
   @Field(() => Float, { nullable: true })
   totalAmount?: number;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => DateTimeScalar, { nullable: true })
   signedAt?: Date;
 }

--- a/services/project-api/src/sales/dto/quote.dto.ts
+++ b/services/project-api/src/sales/dto/quote.dto.ts
@@ -1,8 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, ID, InputType, Int, ObjectType } from '@nestjs/graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { OrderModel } from './order.dto';
 import { CreditReviewModel } from './credit-review.dto';
+
+const DateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @ObjectType()
 export class QuoteItemModel {
@@ -48,16 +50,16 @@ export class QuoteModel {
   @Field(() => Int)
   version!: number;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   createdAt!: Date;
 
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   updatedAt!: Date;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => DateTimeScalar, { nullable: true })
   submittedAt?: Date;
 
-  @Field(() => GraphQLISODateTime, { nullable: true })
+  @Field(() => DateTimeScalar, { nullable: true })
   approvedAt?: Date;
 
   @Field(() => [QuoteItemModel])

--- a/services/project-api/src/sales/metrics/sales-metrics.model.ts
+++ b/services/project-api/src/sales/metrics/sales-metrics.model.ts
@@ -1,10 +1,12 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
-import { GraphQLISODateTime } from 'graphql-scalars';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
+
+const DateTimeScalar = GraphQLDateTime as unknown as GraphQLScalarType<Date, string>;
 
 @ObjectType()
 export class SalesMetricsModel {
-  @Field(() => GraphQLISODateTime)
+  @Field(() => DateTimeScalar)
   generatedAt!: Date;
 
   @Field(() => Int)


### PR DESCRIPTION
## 背景
- E2E テスト実行時に `graphql-scalars` の `GraphQLISODateTime` が存在せずビルドエラーとなる
- Prisma seed のプロジェクト件数が 2 件のみのため E2E 期待値 (>=3) を満たしていなかった

## 変更
- CRM / Sales / HR DTO・モデルで `GraphQLDateTime` を `GraphQLScalarType<Date, string>` として利用し、型エラーを解消
- Prisma seed に Gamma プロジェクトを追加し、E2E シナリオで最低 3 件のプロジェクトが取得されるよう修正

## ログ
- npx eslint src/crm src/sales src/hr
- npm run test -- --testPathPattern=test --runInBand

## 影響
- DTO/モデルの DateTime 定義を共通化、アプリケーション挙動は変更なし（GraphQL 返却値のフォーマットは従来通り）
- E2E テストが再度パスするようになる

## ロールバック
- `git revert 675effd`

## 関連Issue
- #159
