### PR TITLE
feat: add CKM workspace and room UI

### DIFF
--- a/ui-poc/src/app/ckm/[workspaceCode]/page.tsx
+++ b/ui-poc/src/app/ckm/[workspaceCode]/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getCkmWorkspaceDetail } from '@/features/ckm/api';
+
+export const dynamic = 'force-dynamic';
+
+type Params = Promise<{ workspaceCode: string }>;
+
+type Props = {
+  params: Params;
+};
+
+export default async function CkmWorkspaceDetailPage({ params }: Props) {
+  const { workspaceCode } = await params;
+  let workspace;
+  try {
+    workspace = await getCkmWorkspaceDetail(workspaceCode);
+  } catch (error) {
+    console.warn('[ckm] workspace fetch failed', error);
+    return notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-900">{workspace.name}</h1>
+        <p className="mt-1 text-sm text-slate-600">コード: {workspace.code}</p>
+        {workspace.description ? <p className="mt-2 text-sm text-slate-600">{workspace.description}</p> : null}
+        <p className="mt-2 text-xs text-slate-500">
+          {workspace.roomCount} ルーム / {workspace.memberCount} メンバー
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">ルーム一覧</h2>
+        <Link href="/ckm" className="text-sm font-medium text-blue-600 hover:text-blue-500">
+          ワークスペース一覧に戻る
+        </Link>
+      </div>
+
+      {workspace.rooms.length === 0 ? (
+        <p className="rounded border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+          ルームがありません。CKM API でルームを作成してください。
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {workspace.rooms.map((room) => (
+            <li key={room.id} className="rounded border border-slate-200 bg-white p-4 shadow-sm transition hover:border-blue-400">
+              <Link href={`/ckm/${workspace.code}/rooms/${room.id}`} className="block">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">{room.title}</h3>
+                    {room.topic ? <p className="mt-1 text-sm text-slate-600">{room.topic}</p> : null}
+                  </div>
+                  <span className="rounded bg-slate-100 px-3 py-1 text-xs text-slate-600">
+                    {room.memberCount} メンバー
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui-poc/src/app/ckm/[workspaceCode]/rooms/[roomId]/page.tsx
+++ b/ui-poc/src/app/ckm/[workspaceCode]/rooms/[roomId]/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getCkmRoomMessages, getCkmWorkspaceDetail } from '@/features/ckm/api';
+import { CkmRoomView } from '@/features/ckm/CkmRoomView';
+
+export const dynamic = 'force-dynamic';
+
+type Params = Promise<{ workspaceCode: string; roomId: string }>;
+
+type Props = {
+  params: Params;
+};
+
+export default async function CkmRoomPage({ params }: Props) {
+  const { workspaceCode, roomId } = await params;
+  let workspace;
+  try {
+    workspace = await getCkmWorkspaceDetail(workspaceCode);
+  } catch (error) {
+    console.warn('[ckm] workspace fetch failed', error);
+    return notFound();
+  }
+  const room = workspace.rooms.find((candidate) => candidate.id === roomId);
+  if (!room) {
+    return notFound();
+  }
+  const messages = await getCkmRoomMessages(workspaceCode, roomId);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <Link href={`/ckm/${workspace.code}`} className="text-sm font-medium text-blue-600 hover:text-blue-500">
+          ルーム一覧に戻る
+        </Link>
+        <Link href="/ckm" className="text-sm text-slate-500 hover:text-slate-700">
+          ワークスペース一覧
+        </Link>
+      </div>
+      <CkmRoomView workspaceCode={workspace.code} room={room} initialMessages={messages} />
+    </div>
+  );
+}

--- a/ui-poc/src/app/ckm/page.tsx
+++ b/ui-poc/src/app/ckm/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { CkmWorkspaceList } from '@/features/ckm/CkmWorkspaceList';
+import { listCkmWorkspaces } from '@/features/ckm/api';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CkmWorkspacesPage() {
+  const workspaces = await listCkmWorkspaces();
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">CKM ワークスペース</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            docker compose と `npm run prisma:seed:ckm` を利用するとサンプルデータを起動できます。
+          </p>
+        </div>
+        <Link
+          href="/projects"
+          className="text-sm font-medium text-blue-600 hover:text-blue-500"
+        >
+          プロジェクト一覧へ戻る
+        </Link>
+      </div>
+
+      <CkmWorkspaceList workspaces={workspaces} />
+    </div>
+  );
+}

--- a/ui-poc/src/features/ckm/CkmRoomView.tsx
+++ b/ui-poc/src/features/ckm/CkmRoomView.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { postCkmMessage } from './api';
+import type { CkmMessage, CkmChatRoomSummary } from './types';
+
+type Props = {
+  workspaceCode: string;
+  room: CkmChatRoomSummary;
+  initialMessages: CkmMessage[];
+};
+
+function formatRelativeTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const diffMs = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diffMs < minute) {
+    return '数秒前';
+  }
+  if (diffMs < hour) {
+    const minutes = Math.round(diffMs / minute);
+    return `${minutes}分前`;
+  }
+  if (diffMs < day) {
+    const hours = Math.round(diffMs / hour);
+    return `${hours}時間前`;
+  }
+  const days = Math.round(diffMs / day);
+  return `${days}日前`;
+}
+
+export function CkmRoomView({ workspaceCode, room, initialMessages }: Props) {
+  const [messages, setMessages] = useState<CkmMessage[]>(() => initialMessages);
+  const [body, setBody] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const filteredMessages = useMemo(() => {
+    if (!keyword.trim()) {
+      return messages;
+    }
+    const needle = keyword.trim().toLowerCase();
+    return messages.filter((message) => message.body.toLowerCase().includes(needle));
+  }, [messages, keyword]);
+
+  const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    const trimmed = body.trim();
+    if (!trimmed) {
+      return;
+    }
+    startTransition(async () => {
+      try {
+        setError(null);
+        const created = await postCkmMessage({
+          workspaceCode,
+          roomId: room.id,
+          body: trimmed,
+        });
+        setMessages((prev) => [created, ...prev]);
+        setBody('');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <header className="rounded border border-slate-200 bg-white p-4 shadow-sm">
+        <h1 className="text-xl font-semibold text-slate-900">{room.title}</h1>
+        {room.topic ? <p className="mt-1 text-sm text-slate-600">{room.topic}</p> : null}
+        <p className="mt-2 text-xs text-slate-500">{room.memberCount} メンバー</p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="rounded border border-slate-200 bg-white p-4 shadow-sm">
+        <label className="block text-sm font-medium text-slate-700">メッセージを投稿</label>
+        <textarea
+          className="mt-2 w-full rounded border border-slate-300 p-2 text-sm shadow-inner focus:border-blue-500 focus:outline-none"
+          rows={3}
+          value={body}
+          onChange={(evt) => setBody(evt.target.value)}
+          placeholder="リアルタイムで共有したい内容を入力してください"
+          disabled={isPending}
+        />
+        <div className="mt-3 flex items-center justify-between">
+          <div className="text-xs text-slate-500">
+            `X-User-Id` ヘッダーには <code>{process.env.NEXT_PUBLIC_CKM_USER_ID ?? 'user-alice'}</code> が利用されます。
+          </div>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+            disabled={isPending || body.trim().length === 0}
+          >
+            {isPending ? '送信中…' : '送信'}
+          </button>
+        </div>
+        {error ? <p className="mt-3 text-sm text-red-600">投稿に失敗しました: {error}</p> : null}
+      </form>
+
+      <div className="rounded border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">最近のメッセージ</h2>
+          <input
+            type="search"
+            placeholder="メッセージ検索"
+            value={keyword}
+            onChange={(evt) => setKeyword(evt.target.value)}
+            className="w-56 rounded border border-slate-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+        {filteredMessages.length === 0 ? (
+          <p className="rounded border border-dashed border-slate-200 bg-slate-50 p-4 text-sm text-slate-500">
+            メッセージがありません。最初の投稿を作成しましょう。
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {filteredMessages.map((message) => (
+             <li key={message.id} className="rounded border border-slate-200 p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-semibold text-slate-900">{message.authorId}</span>
+                  <span className="text-xs text-slate-500">
+                    {formatRelativeTime(message.postedAt)} ({new Date(message.postedAt).toLocaleString()})
+                  </span>
+                </div>
+                <p className="mt-1 whitespace-pre-wrap text-sm text-slate-700">{message.body}</p>
+                {message.deletedAt ? <p className="mt-1 text-xs text-red-500">このメッセージは削除されました。</p> : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui-poc/src/features/ckm/CkmWorkspaceList.tsx
+++ b/ui-poc/src/features/ckm/CkmWorkspaceList.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import type { CkmWorkspaceSummary } from './types';
+
+type Props = {
+  workspaces: CkmWorkspaceSummary[];
+};
+
+export function CkmWorkspaceList({ workspaces }: Props) {
+  if (workspaces.length === 0) {
+    return (
+      <div className="rounded border border-dashed border-slate-300 bg-slate-50 p-6 text-sm text-slate-600">
+        CKM ワークスペースがまだありません。`npm run prisma:seed:ckm` でサンプルデータを投入できます。
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {workspaces.map((workspace) => (
+        <Link
+          key={workspace.id}
+          href={`/ckm/${workspace.code}`}
+          className="block rounded border border-slate-200 bg-white p-4 shadow-sm transition hover:border-blue-400 hover:shadow"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">{workspace.name}</h2>
+              <p className="text-sm text-slate-500">コード: {workspace.code}</p>
+            </div>
+            <span className="rounded bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+              {workspace.roomCount} ルーム / {workspace.memberCount} メンバー
+            </span>
+          </div>
+          {workspace.description ? (
+            <p className="mt-2 text-sm text-slate-600">{workspace.description}</p>
+          ) : null}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/ui-poc/src/features/ckm/api.ts
+++ b/ui-poc/src/features/ckm/api.ts
@@ -1,0 +1,96 @@
+import { apiRequest, graphqlRequest } from '@/lib/api-client';
+import type { CkmWorkspaceDetail, CkmWorkspaceSummary, CkmMessage, PostMessageInput } from './types';
+
+const DEFAULT_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3001';
+
+const WORKSPACE_SUMMARIES_QUERY = /* GraphQL */ `
+  query CkmWorkspaceSummaries {
+    ckmWorkspaces {
+      id
+      code
+      name
+      description
+      defaultRole
+      isPrivate
+      roomCount
+      memberCount
+    }
+  }
+`;
+
+const WORKSPACE_DETAIL_QUERY = /* GraphQL */ `
+  query CkmWorkspaceDetail($code: String!) {
+    ckmWorkspace(code: $code) {
+      id
+      code
+      name
+      description
+      defaultRole
+      isPrivate
+      roomCount
+      memberCount
+      rooms {
+        id
+        title
+        topic
+        roomType
+        isPrivate
+        memberCount
+      }
+    }
+  }
+`;
+
+const ROOM_MESSAGES_QUERY = /* GraphQL */ `
+  query CkmRoomMessages($workspaceCode: String!, $roomId: String!, $keyword: String) {
+    ckmMessageSearch(workspaceCode: $workspaceCode, roomId: $roomId, keyword: $keyword) {
+      id
+      roomId
+      threadId
+      parentMessageId
+      authorId
+      messageType
+      priority
+      body
+      bodyRich
+      mentions
+      metadataJson
+      postedAt
+      deletedAt
+    }
+  }
+`;
+
+export async function listCkmWorkspaces(): Promise<CkmWorkspaceSummary[]> {
+  const data = await graphqlRequest<{ ckmWorkspaces: CkmWorkspaceSummary[] }>({
+    query: WORKSPACE_SUMMARIES_QUERY,
+  });
+  return data.ckmWorkspaces;
+}
+
+export async function getCkmWorkspaceDetail(code: string): Promise<CkmWorkspaceDetail> {
+  const data = await graphqlRequest<{ ckmWorkspace: CkmWorkspaceDetail }>({
+    query: WORKSPACE_DETAIL_QUERY,
+    variables: { code },
+  });
+  return data.ckmWorkspace;
+}
+
+export async function getCkmRoomMessages(workspaceCode: string, roomId: string, keyword?: string): Promise<CkmMessage[]> {
+  const data = await graphqlRequest<{
+    ckmMessageSearch: CkmMessage[];
+  }>({
+    query: ROOM_MESSAGES_QUERY,
+    variables: { workspaceCode, roomId, keyword },
+  });
+  return data.ckmMessageSearch;
+}
+
+export async function postCkmMessage(input: PostMessageInput): Promise<CkmMessage> {
+  return apiRequest<CkmMessage>({
+    path: '/api/v1/ckm/messages',
+    method: 'POST',
+    baseUrl: DEFAULT_BASE,
+    body: JSON.stringify(input),
+  });
+}

--- a/ui-poc/src/features/ckm/types.ts
+++ b/ui-poc/src/features/ckm/types.ts
@@ -1,0 +1,51 @@
+export type CkmWorkspaceSummary = {
+  id: string;
+  code: string;
+  name: string;
+  description?: string | null;
+  defaultRole: string;
+  isPrivate: boolean;
+  roomCount: number;
+  memberCount: number;
+};
+
+export type CkmChatRoomSummary = {
+  id: string;
+  title: string;
+  topic?: string | null;
+  roomType: string;
+  isPrivate: boolean;
+  memberCount: number;
+};
+
+export type CkmWorkspaceDetail = CkmWorkspaceSummary & {
+  rooms: CkmChatRoomSummary[];
+};
+
+export type CkmMessage = {
+  id: string;
+  roomId: string;
+  threadId?: string | null;
+  parentMessageId?: string | null;
+  authorId: string;
+  messageType: string;
+  priority: number;
+  body: string;
+  bodyRich?: string | null;
+  mentions?: string[] | null;
+  metadataJson?: string | null;
+  postedAt: string;
+  deletedAt?: string | null;
+};
+
+export type PostMessageInput = {
+  workspaceCode: string;
+  roomId: string;
+  body: string;
+  threadId?: string;
+  parentMessageId?: string;
+  messageType?: string;
+  priority?: number;
+  mentions?: string[];
+  metadataJson?: string;
+};

--- a/ui-poc/src/lib/api-client-base.ts
+++ b/ui-poc/src/lib/api-client-base.ts
@@ -1,5 +1,14 @@
 const defaultBase = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:3001';
 const enableLogging = (process.env.NEXT_PUBLIC_ENABLE_API_LOGGING ?? 'false').toLowerCase() === 'true';
+const defaultCkmUserId = (process.env.NEXT_PUBLIC_CKM_USER_ID ?? 'user-alice').trim();
+
+const buildAuthHeaders = (headers?: HeadersInit): HeadersInit => {
+  const ckmUserId = defaultCkmUserId;
+  return {
+    'X-User-Id': ckmUserId,
+    ...headers,
+  };
+};
 
 export type ApiRequestOptions = RequestInit & {
   path: string;
@@ -29,7 +38,7 @@ export async function apiRequestInternal<T>(options: ApiRequestOptions): Promise
   const url = new URL(path, baseUrl).toString();
   const requestHeaders = {
     'Content-Type': 'application/json',
-    ...headers,
+    ...buildAuthHeaders(headers),
   } satisfies HeadersInit;
 
   if (enableLogging) {
@@ -71,7 +80,7 @@ export async function graphqlRequestInternal<TData, TVars extends Record<string,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      ...headers,
+      ...buildAuthHeaders(headers),
     },
     body: JSON.stringify({ query, variables }),
     cache: 'no-store',


### PR DESCRIPTION
## 背景
- Issue #320 の一環として CKM チャットを UI から操作できる状態にする必要がある
- まずは最小の閲覧・投稿フロー（ワークスペース一覧 → ルーム → メッセージ投稿）を構築

## 変更
- `NEXT_PUBLIC_CKM_USER_ID` を参照して `X-User-Id` ヘッダーを自動付与するよう API クライアントを拡張
- CKM 用 GraphQL/REST ラッパ (`listCkmWorkspaces` / `getCkmWorkspaceDetail` / `getCkmRoomMessages` / `postCkmMessage`) を追加
- App Router に `/ckm`、`/ckm/[workspaceCode]`、`/ckm/[workspaceCode]/rooms/[roomId]` を追加し、ワークスペース/ルーム/メッセージ UI を実装
- メッセージ投稿フォームと簡易検索を備えたクライアントコンポーネントを追加

## ログ
- `npm run test -- ckm`

## テスト
- 手動: `docker compose -f docker/docker-compose.ckm.yml up -d` → `npm run prisma:seed:ckm` → `npm run dev` (ui-poc)
  - `.env.local` に `NEXT_PUBLIC_CKM_USER_ID=user-alice` を設定し `/ckm` へアクセス
  - ルームでメッセージ投稿すると即座に一覧へ反映されることを確認

## 影響
- 新規 CKM ページが追加され、`NEXT_PUBLIC_CKM_USER_ID` 未設定時は `user-alice` が既定で利用される
- 既存 Projects/Timesheets 等への影響なし

## ロールバック
- 本PRのマージコミットを `git revert` してください

## 関連Issue
- #320
